### PR TITLE
docs: publish current GitHub listing and README locators

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # 🗑️ Google Photos Delete Tool
 
-<p align="center">
-  <img src="https://mark.sylphx.com/api/v1/banner?type=constellation&theme=tokyonight&text=Google+Photos+Delete+Tool&desc=Consent-gated+bulk+delete+for+Google+Photos&height=200&animation=rise&credit=0" alt="Google-Photos-Delete-Tool — Sylphx Mark banner" width="100%" />
-</p>
+Consent-gated bulk delete for Google Photos: batch select, dry-run, and empty-trash.
+
+- Ordinary: https://chromewebstore.google.com/detail/google-photos-delete-tool/jiahfbbfpacpolomdjlpdpiljllcdenb — published Chrome Web Store listing (item `jiahfbbfpacpolomdjlpdpiljllcdenb`, observed live version 3.0.1 with Add to Chrome). Store listing is the ordinary customer surface for this extension. A store `200` is not the product contract.
+- Preview: `none` — GitHub Pages is not enabled, and this product has no admitted preview, dogfood, or marketing website. Do not invent a URL.
+- Vision: [`docs/vision.md`](docs/vision.md)
+- Capabilities: [`docs/capabilities.md`](docs/capabilities.md)
 
 [![CI](https://github.com/shtse8/Google-Photos-Delete-Tool/actions/workflows/ci.yml/badge.svg)](https://github.com/shtse8/Google-Photos-Delete-Tool/actions/workflows/ci.yml)
 [![Release](https://github.com/shtse8/Google-Photos-Delete-Tool/actions/workflows/release.yml/badge.svg)](https://github.com/shtse8/Google-Photos-Delete-Tool/actions/workflows/release.yml)
@@ -27,7 +30,7 @@ empty.
 
 | Surface | How to get it | Notes |
 |---|---|---|
-| **Chrome / Firefox extension** | Chrome Web Store / Firefox Add-ons | Full popup UI, badge, i18n (9 languages), empty-trash flow |
+| **Chrome / Firefox extension** | [Chrome Web Store](https://chromewebstore.google.com/detail/google-photos-delete-tool/jiahfbbfpacpolomdjlpdpiljllcdenb); Firefox Add-ons not published | Full popup UI, badge, i18n (9 languages), empty-trash flow. Firefox artifact exists in source; the AMO listing is unpublished (404). |
 | **Userscript** (Tampermonkey / Violentmonkey / Greasemonkey) | `google-photos-delete.user.js` from the latest release | Same engine, same floating panel, same safety model |
 
 The bookmarklet and DevTools-console distributions were **removed** in v3:


### PR DESCRIPTION
## Outcome

README now states the one-sentence purpose with explicit Ordinary and Preview locators. Vision and capabilities files already landed on `master` (`#5`) and are linked, not rewritten. The GitHub listing description is set to that same sentence. Homepage stays the published Chrome Web Store listing.

## Boundaries

- Write/effect set: `README.md` plus `gh repo edit` on `shtse8/Google-Photos-Delete-Tool`.
- No dest/graph edit, product code, storefront JSON, merge, or live store mutation.
- A store `200` is not the product contract. This PR is not live-browser proof.

## Honesty

- One-sentence purpose: `Consent-gated bulk delete for Google Photos: batch select, dry-run, and empty-trash.`
- Ordinary: https://chromewebstore.google.com/detail/google-photos-delete-tool/jiahfbbfpacpolomdjlpdpiljllcdenb — published Chrome Web Store listing (item `jiahfbbfpacpolomdjlpdpiljllcdenb`). Observed live title `Google Photos Delete Tool`, version `3.0.1`, and Add to Chrome. Store listing is the ordinary customer surface.
- Preview: `none` — GitHub Pages is not enabled (`404`). No product website is admitted. A website URL was not invented.
- Vision: `docs/vision.md` (present on `origin/master` after `#5`)
- Capabilities: `docs/capabilities.md` (present on `origin/master` after `#5`)
- Firefox Add-ons slug and API search for this product: unpublished (`404`). Edge add-on slug: `404`.
- Current GitHub description claimed Firefox, userscript, and standalone as if they were the listing surface. Standalone is a development artifact. Firefox is unpublished. The listing sentence no longer carries those claims.
- Mark banner `https://mark.sylphx.com/api/v1/banner?...` returned `404`; it is removed.

## Listing edit

`gh repo edit` on `shtse8/Google-Photos-Delete-Tool` is part of this write-set and is applied with the same purpose + CWS homepage. That listing write is not in git.

## Verification

- `git diff --stat origin/master...HEAD` is `README.md` only
- Live CWS probe: canonical slug URL, version `3.0.1`, Add to Chrome
- `gh api repos/shtse8/Google-Photos-Delete-Tool/pages` → `404`
- AMO listing/API for this product → `404`
- Mark banner probe → `404`

## Not claimed

- This PR is not product completion.
- CI is not waited on and is not treated as delivery proof.
- CWS reachability is not a live Google Photos deletion proof.