### PR TITLE
docs: lock Google Photos Delete Tool identity graph fates

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -1,21 +1,62 @@
-# Google Photos Delete Tool capability graph
+# Google Photos Delete Tool identity graph
 
 The destination is [vision.md](vision.md). This graph records durable product
-responsibilities and true dependency edges, not a work queue, release status, or
-claim that a live browser run has passed.
+identities, fates, and true dependency edges, not a work queue, release status,
+or claim that a live browser run has passed.
 
-| ID | Capability | Depends on | Done when |
-| --- | --- | --- | --- |
-| GPDT-ENTER | Enter a supported, locally controlled surface | — | The extension or userscript activates only for `photos.google.com`, identifies the chosen current view as the action scope, and offers a click-free dry-run before destructive work. |
-| GPDT-OBSERVE | Interpret the current Google Photos DOM fail closed | GPDT-ENTER | A versioned pack identifies media tiles, selection state, scroll container, dialogs, and destructive candidates; action candidates require a pack-owned exact action selector or positive accessible text, unknown DOM returns no candidate, and bounded diagnostics retain the pack and observed match evidence. |
-| GPDT-PREVIEW | Preview the current-view scope without mutation | GPDT-OBSERVE | The dry-run path scrolls and counts observed matching labels without invoking any click, clearly treats deduplicated label counts as browser observations, and can be stopped without becoming a destructive run. |
-| GPDT-CONSENT | Admit explicit destructive intent | GPDT-ENTER | Every non-dry run is refused when the shared local consent acknowledgement is absent or unreadable, and choosing the permanent empty-trash option makes that consequence visible before admission. |
-| GPDT-BATCH | Move matching media to Trash through bounded actions | GPDT-OBSERVE, GPDT-CONSENT | The engine selects only currently unchecked matching tiles up to the configured positive batch limit, bounds selection settling, scroll settling, end-of-list detection, and action/dialog waits, and clicks delete and confirm only after positive identification. |
-| GPDT-BATCH-VERIFY | Verify each recoverable deletion batch | GPDT-BATCH | After confirmation, the engine waits within the action timeout for the selected count to return to zero, increments the deleted total only after that observation, flushes a final partial batch, and reports timeout or selector drift as error instead of `done`. |
-| GPDT-CONTROL | Keep a run under present user control | GPDT-BATCH | Pause holds progress, resume continues the same engine, stop interrupts action waits and resolves to idle, and a supported surface cannot start a second engine while the first run is settling. |
-| GPDT-TRASH-HANDOFF | Bound navigation into the permanent Trash flow | GPDT-BATCH-VERIFY, GPDT-CONSENT | Navigation occurs only when the explicit empty-trash option survived a clean real run that deleted at least one item; a successfully persisted handoff is consumed once, expires after three minutes, and is accepted only on `/trash` or its subpaths. |
-| GPDT-EMPTY-VERIFY | Empty Trash only with an exact observed postcondition | GPDT-OBSERVE, GPDT-TRASH-HANDOFF | The flow positively identifies the empty action, dialog, and destructive confirmation within per-step timeouts, then emits `done` only after the action and dialog disappear or an explicit empty-state signal appears; ambiguous or unverifiable state emits an error. |
-| GPDT-EVIDENCE | Qualify behavior against the live Google Photos surface | GPDT-PREVIEW, GPDT-BATCH-VERIFY, GPDT-CONTROL, GPDT-EMPTY-VERIFY | Source and local tests pass, and each release making a live claim records the disposable-account checks in `RELEASE_GATE.md`: seeded-item counts, batch resets, exact Trash contents, empty-trash postcondition, stop/restart, and a localized run. |
+One colloquial name has one row and one fate (`live`, `dead`, or
+`rename-to:<ID>`). Every identity below is `live`. This conversion does not
+invent a second destination: IDs, identity text, edges, and done-when oracles
+are unchanged.
+
+## Graph
+
+Edges point from prerequisite to consumer. The table is authority if this
+picture omits or invents an edge.
+
+```mermaid
+flowchart TD
+  GPDT_ENTER["GPDT-ENTER"]
+  GPDT_OBSERVE["GPDT-OBSERVE"]
+  GPDT_PREVIEW["GPDT-PREVIEW"]
+  GPDT_CONSENT["GPDT-CONSENT"]
+  GPDT_BATCH["GPDT-BATCH"]
+  GPDT_BATCH_VERIFY["GPDT-BATCH-VERIFY"]
+  GPDT_CONTROL["GPDT-CONTROL"]
+  GPDT_TRASH_HANDOFF["GPDT-TRASH-HANDOFF"]
+  GPDT_EMPTY_VERIFY["GPDT-EMPTY-VERIFY"]
+  GPDT_EVIDENCE["GPDT-EVIDENCE"]
+  GPDT_ENTER --> GPDT_OBSERVE
+  GPDT_ENTER --> GPDT_CONSENT
+  GPDT_OBSERVE --> GPDT_PREVIEW
+  GPDT_OBSERVE --> GPDT_BATCH
+  GPDT_CONSENT --> GPDT_BATCH
+  GPDT_BATCH --> GPDT_BATCH_VERIFY
+  GPDT_BATCH --> GPDT_CONTROL
+  GPDT_BATCH_VERIFY --> GPDT_TRASH_HANDOFF
+  GPDT_CONSENT --> GPDT_TRASH_HANDOFF
+  GPDT_OBSERVE --> GPDT_EMPTY_VERIFY
+  GPDT_TRASH_HANDOFF --> GPDT_EMPTY_VERIFY
+  GPDT_PREVIEW --> GPDT_EVIDENCE
+  GPDT_BATCH_VERIFY --> GPDT_EVIDENCE
+  GPDT_CONTROL --> GPDT_EVIDENCE
+  GPDT_EMPTY_VERIFY --> GPDT_EVIDENCE
+```
+
+## Registry
+
+| ID | Identity | Fate | Depends on | Done when |
+| --- | --- | --- | --- | --- |
+| GPDT-ENTER | Enter a supported, locally controlled surface | live | — | The extension or userscript activates only for `photos.google.com`, identifies the chosen current view as the action scope, and offers a click-free dry-run before destructive work. |
+| GPDT-OBSERVE | Interpret the current Google Photos DOM fail closed | live | GPDT-ENTER | A versioned pack identifies media tiles, selection state, scroll container, dialogs, and destructive candidates; action candidates require a pack-owned exact action selector or positive accessible text, unknown DOM returns no candidate, and bounded diagnostics retain the pack and observed match evidence. |
+| GPDT-PREVIEW | Preview the current-view scope without mutation | live | GPDT-OBSERVE | The dry-run path scrolls and counts observed matching labels without invoking any click, clearly treats deduplicated label counts as browser observations, and can be stopped without becoming a destructive run. |
+| GPDT-CONSENT | Admit explicit destructive intent | live | GPDT-ENTER | Every non-dry run is refused when the shared local consent acknowledgement is absent or unreadable, and choosing the permanent empty-trash option makes that consequence visible before admission. |
+| GPDT-BATCH | Move matching media to Trash through bounded actions | live | GPDT-OBSERVE, GPDT-CONSENT | The engine selects only currently unchecked matching tiles up to the configured positive batch limit, bounds selection settling, scroll settling, end-of-list detection, and action/dialog waits, and clicks delete and confirm only after positive identification. |
+| GPDT-BATCH-VERIFY | Verify each recoverable deletion batch | live | GPDT-BATCH | After confirmation, the engine waits within the action timeout for the selected count to return to zero, increments the deleted total only after that observation, flushes a final partial batch, and reports timeout or selector drift as error instead of `done`. |
+| GPDT-CONTROL | Keep a run under present user control | live | GPDT-BATCH | Pause holds progress, resume continues the same engine, stop interrupts action waits and resolves to idle, and a supported surface cannot start a second engine while the first run is settling. |
+| GPDT-TRASH-HANDOFF | Bound navigation into the permanent Trash flow | live | GPDT-BATCH-VERIFY, GPDT-CONSENT | Navigation occurs only when the explicit empty-trash option survived a clean real run that deleted at least one item; a successfully persisted handoff is consumed once, expires after three minutes, and is accepted only on `/trash` or its subpaths. |
+| GPDT-EMPTY-VERIFY | Empty Trash only with an exact observed postcondition | live | GPDT-OBSERVE, GPDT-TRASH-HANDOFF | The flow positively identifies the empty action, dialog, and destructive confirmation within per-step timeouts, then emits `done` only after the action and dialog disappear or an explicit empty-state signal appears; ambiguous or unverifiable state emits an error. |
+| GPDT-EVIDENCE | Qualify behavior against the live Google Photos surface | live | GPDT-PREVIEW, GPDT-BATCH-VERIFY, GPDT-CONTROL, GPDT-EMPTY-VERIFY | Source and local tests pass, and each release making a live claim records the disposable-account checks in `RELEASE_GATE.md`: seeded-item counts, batch resets, exact Trash contents, empty-trash postcondition, stop/restart, and a localized run. |
 
 ## Repository evidence
 

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,7 +1,9 @@
 # Google Photos Delete Tool vision
 
-This file is the canonical product destination. It is not a current milestone,
-release claim, or proof that Google Photos' live DOM still matches the tool.
+This file is the canonical product destination. Durable identities, fates,
+dependencies, and oracles live in [capabilities.md](capabilities.md):
+one colloquial name has one fate. It is not a current milestone, release
+claim, or proof that Google Photos' live DOM still matches the tool.
 
 ## What finished is
 
@@ -65,5 +67,6 @@ known seeded items, per-batch counter resets, exact Trash contents, the
 empty-state postcondition, stop/restart behavior, and a localized run. Docs, CI,
 a store listing, or a release artifact alone are not live-browser proof.
 
-The durable product responsibilities and dependency edges are in
-[capabilities.md](capabilities.md).
+The identity graph in [capabilities.md](capabilities.md) owns identity, fate,
+dependency edges, and done-when oracles. This destination does not assign a
+second fate to any name there.


### PR DESCRIPTION
## Identity

- **identity:** Google Photos Delete Tool identity graph (`docs/capabilities.md`) — dest lock of existing `GPDT-*` names
- **fate:** `live` for every current row; no `dead` or `rename-to` invented
- **outcome:** one colloquial name has one fate

## Write-set

`docs/vision.md` + `docs/capabilities.md` only.

- Registry shape is `ID | Identity | Fate | Depends on | Done when`
- Identity names are the previous Capability names
- Mermaid flowchart IDs and edges match the table
- Vision still owns destination and points at this graph; it does not assign a second fate
- Identity set, dependencies, and `Done when` oracles are unchanged

## Oracle

This dest lock is true when:

1. `docs/capabilities.md` is an identity graph, not a four-column capability table
2. each of the ten `GPDT-*` names has exactly one row and fate `live`
3. Mermaid node IDs equal registry IDs, and Mermaid edges equal `Depends on`
4. `docs/vision.md` destination, users, non-goals, and customer oracle are the same product; only graph-authority language changed
5. `git diff --name-only origin/master...HEAD` is exactly those two files

## Evidence layer

Source: this change's tree. Not live-browser proof, store state, or a merge.

## Next action

A different session reviews this SHA. Do not merge from this Worker. The forge waits.

- base: `master@33fa86a7114637528bb0f8449cacd6a01b7cd625`
- candidate_sha: `64675d078a0edbbe48939f2670dc24a40067846b`