### PR TITLE
feat: admit GPDT-ENTER only on photos.google.com

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -11,6 +11,7 @@
  * not support service_worker) and adds browser_specific_settings.
  */
 import { build } from 'vite'
+import { SUPPORTED_MATCH_PATTERN } from '../src/core/surface'
 import { fileURLToPath } from 'node:url'
 import { resolve } from 'path'
 import {
@@ -193,7 +194,7 @@ const userscriptHeader = `// ==UserScript==
 // @version      ${pkg.version}
 // @description  Bulk delete photos on photos.google.com with batch select, dry-run, and empty-trash (consent-gated)
 // @author       Kyle Tse
-// @match        https://photos.google.com/*
+// @match        ${SUPPORTED_MATCH_PATTERN}
 // @grant        none
 // @homepage     https://github.com/shtse8/Google-Photos-Delete-Tool
 // @supportURL   https://github.com/shtse8/Google-Photos-Delete-Tool/issues

--- a/scripts/verify.ts
+++ b/scripts/verify.ts
@@ -13,6 +13,7 @@
  *   - popup assets (html/css/icons) present
  */
 import { readFileSync, existsSync } from 'fs'
+import { SUPPORTED_MATCH_PATTERN } from '../src/core/surface'
 import { fileURLToPath } from 'node:url'
 import { resolve } from 'path'
 
@@ -47,7 +48,8 @@ console.log('verify: package version =', pkg.version)
   )
   check(!m.background?.scripts, 'chrome background has no scripts array')
   check(m.permissions?.length === 1 && m.permissions[0] === 'storage', 'chrome permissions == ["storage"]')
-  check(Array.isArray(m.host_permissions) && m.host_permissions.includes('https://photos.google.com/*'), 'chrome host_permissions cover photos.google.com')
+  check(Array.isArray(m.host_permissions) && m.host_permissions.includes(SUPPORTED_MATCH_PATTERN), 'chrome host_permissions cover photos.google.com')
+  check(Array.isArray(m.content_scripts?.[0]?.matches) && m.content_scripts[0].matches.includes(SUPPORTED_MATCH_PATTERN), 'chrome content_scripts match photos.google.com')
 }
 
 // ─── Firefox manifest ───────────────────────────────────────────
@@ -112,7 +114,7 @@ for (const dir of ['extension', 'extension-firefox']) {
 {
   const header = read('dist/userscript/google-photos-delete.user.js').split('\n').slice(0, 30).join('\n')
   check(header.includes(`// @version      ${pkg.version}`), 'userscript @version == package version')
-  check(header.includes('// @match        https://photos.google.com/*'), 'userscript @match covers photos.google.com')
+  check(header.includes(`// @match        ${SUPPORTED_MATCH_PATTERN}`), 'userscript @match covers photos.google.com')
   check(header.includes('// @grant        none'), 'userscript @grant none')
   check(!header.includes('bookmarklet'), 'userscript header has no bookmarklet residue')
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -65,3 +65,17 @@ export {
   type EmptyTrashBaton,
   type PendingEval,
 } from './empty-trash-baton'
+
+export {
+  SUPPORTED_HOST,
+  SUPPORTED_ORIGIN,
+  SUPPORTED_MATCH_PATTERN,
+  isSupportedPhotosUrl,
+  identifyPhotosView,
+  admitSurface,
+  activateLocalSurface,
+  describePhotosView,
+  type PhotosView,
+  type PhotosViewKind,
+  type SurfaceAdmission,
+} from './surface'

--- a/src/core/surface.ts
+++ b/src/core/surface.ts
@@ -1,0 +1,157 @@
+/**
+ * GPDT-ENTER — supported-surface admission.
+ *
+ * One authority for "are we on photos.google.com, and which current
+ * view is the action scope?". Extension popup, content script,
+ * userscript, and standalone all consult this module; they must not
+ * invent a second host check (especially not a substring `includes`).
+ *
+ * A match here is not authority to delete. Dry-run is the click-free
+ * preview of the admitted view; destructive work still needs consent.
+ */
+export const SUPPORTED_HOST = 'photos.google.com'
+export const SUPPORTED_ORIGIN = 'https://photos.google.com'
+export const SUPPORTED_MATCH_PATTERN = 'https://photos.google.com/*'
+
+export type PhotosViewKind =
+  | 'library'
+  | 'albums'
+  | 'album'
+  | 'search'
+  | 'trash'
+  | 'photo'
+  | 'memory'
+  | 'share'
+  | 'places'
+  | 'collections'
+  | 'other'
+
+export interface PhotosView {
+  kind: PhotosViewKind
+  /** Path after an optional `/u/<n>` prefix; always starts with `/`. */
+  path: string
+  /** Google account index when the URL is `/u/<n>/…`. */
+  account?: string
+  /** Album id, search query, photo id, etc. when the path carries one. */
+  target?: string
+}
+
+export type SurfaceAdmission =
+  | { ok: true; view: PhotosView }
+  | { ok: false; reason: 'unsupported-url' }
+
+const USER_PREFIX = /^\/u\/(\d+)(?=\/|$)/
+
+const KIND_BY_HEAD: Readonly<Record<string, PhotosViewKind>> = {
+  albums: 'albums',
+  album: 'album',
+  search: 'search',
+  trash: 'trash',
+  photo: 'photo',
+  memory: 'memory',
+  share: 'share',
+  sharing: 'share',
+  places: 'places',
+  collections: 'collections',
+}
+
+const TARGETABLE = new Set<PhotosViewKind>([
+  'album',
+  'search',
+  'photo',
+  'memory',
+  'share',
+])
+
+const KIND_LABEL_EN: Readonly<Record<PhotosViewKind, string>> = {
+  library: 'Library',
+  albums: 'Albums',
+  album: 'Album',
+  search: 'Search',
+  trash: 'Trash',
+  photo: 'Photo',
+  memory: 'Memory',
+  share: 'Shared',
+  places: 'Places',
+  collections: 'Collections',
+  other: 'This view',
+}
+
+/**
+ * Exact https://photos.google.com admission. Rejects lookalike hosts,
+ * non-https, credentials, and non-default ports. `undefined`/`null`/
+ * empty input is unsupported (the popup sees that for tabs it cannot
+ * read).
+ */
+export function isSupportedPhotosUrl(raw: string | null | undefined): boolean {
+  if (typeof raw !== 'string' || raw.length === 0) return false
+  let url: URL
+  try {
+    url = new URL(raw)
+  } catch {
+    return false
+  }
+  return (
+    url.protocol === 'https:' &&
+    url.hostname.toLowerCase() === SUPPORTED_HOST &&
+    url.port === '' &&
+    url.username === '' &&
+    url.password === ''
+  )
+}
+
+function decodeSegment(segment: string): string {
+  try {
+    return decodeURIComponent(segment)
+  } catch {
+    return segment
+  }
+}
+
+/**
+ * Identify the current Google Photos view that will be the action
+ * scope. Returns `null` when the URL is not a supported surface.
+ */
+export function identifyPhotosView(raw: string | null | undefined): PhotosView | null {
+  if (!isSupportedPhotosUrl(raw)) return null
+  const url = new URL(raw as string)
+  let path = url.pathname
+  let account: string | undefined
+  const user = path.match(USER_PREFIX)
+  if (user) {
+    account = user[1]
+    path = path.slice(user[0].length)
+  }
+  if (path === '' || path === '/') {
+    return { kind: 'library', path: '/', account }
+  }
+  if (!path.startsWith('/')) path = `/${path}`
+  const segments = path.slice(1).split('/').filter(Boolean)
+  const head = segments[0] ?? ''
+  const kind = KIND_BY_HEAD[head] ?? 'other'
+  const target = TARGETABLE.has(kind) && segments[1] ? decodeSegment(segments[1]) : undefined
+  return { kind, path, account, target }
+}
+
+export function admitSurface(raw: string | null | undefined): SurfaceAdmission {
+  const view = identifyPhotosView(raw)
+  if (!view) return { ok: false, reason: 'unsupported-url' }
+  return { ok: true, view }
+}
+
+/**
+ * Userscript / standalone mount gate. Does not mount off-host, so a
+ * pasted inject script cannot attach a panel on an unrelated site.
+ */
+export function activateLocalSurface(href: string, mount: () => void): 'activated' | 'refused' {
+  if (!admitSurface(href).ok) return 'refused'
+  mount()
+  return 'activated'
+}
+
+/** English label for the in-page panel (English-only by design). */
+export function describePhotosView(view: PhotosView): string {
+  if (view.kind === 'other') return view.path
+  const kind = KIND_LABEL_EN[view.kind]
+  return view.target ? `${kind} · ${view.target}` : kind
+}

--- a/src/extension/content.ts
+++ b/src/extension/content.ts
@@ -25,6 +25,7 @@ import { diagnostics } from '../core/diagnostics'
 import { evaluatePendingEmptyTrash, TRASH_URL } from '../core/empty-trash-baton'
 import { runEmptyTrashFlow, type EmptyTrashStatus } from '../core/empty-trash'
 import type { RunStatus } from '../core/status'
+import { isSupportedPhotosUrl } from '../core/surface'
 import { createChromeBaton, runtimeSendMessage, storageGet, storageRemove, storageSet } from './api'
 
 const LOG = '[gpdt:content]'
@@ -50,6 +51,9 @@ interface StartOptions {
 }
 
 const start = async (opts: StartOptions): Promise<{ ok: boolean; error?: string }> => {
+  if (!isSupportedPhotosUrl(window.location.href)) {
+    return { ok: false, error: 'Not on photos.google.com.' }
+  }
   if (engine || runPromise || starting) {
     return { ok: false, error: 'A run is already in progress — stop it first.' }
   }
@@ -290,4 +294,6 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 // ─── Bootstrap ──────────────────────────────────────────────────
 
 console.log(`${LOG} loaded on ${window.location.pathname}`)
-void maybeRunPendingEmptyTrash()
+if (isSupportedPhotosUrl(window.location.href)) {
+  void maybeRunPendingEmptyTrash()
+}

--- a/src/extension/popup/i18n/locales/de.ts
+++ b/src/extension/popup/i18n/locales/de.ts
@@ -33,7 +33,7 @@ const de: Translations = {
     },
     dryRun: {
       label: "Testlauf",
-      hint: "Nur zählen, nicht löschen",
+      hint: "Diese Ansicht ohne Klick prüfen",
     },
     emptyTrash: {
       label: "Papierkorb leeren",
@@ -82,6 +82,20 @@ const de: Translations = {
     check: "Ich verstehe und befinde mich in der Google-Photos-Ansicht, die ich bereinigen möchte.",
     confirm: "Bestätigen und starten",
     cancel: "Abbrechen",
+  },
+  scope: {
+    actingOn: "Aktionsbereich: {view}",
+    library: "Bibliothek",
+    albums: "Alben",
+    album: "Album",
+    search: "Suche",
+    trash: "Papierkorb",
+    photo: "Foto",
+    memory: "Erinnerung",
+    share: "Geteilt",
+    places: "Orte",
+    collections: "Sammlungen",
+    other: "Diese Ansicht ({path})",
   },
 }
 

--- a/src/extension/popup/i18n/locales/en.ts
+++ b/src/extension/popup/i18n/locales/en.ts
@@ -33,7 +33,7 @@ const en: Translations = {
     },
     dryRun: {
       label: "Dry run",
-      hint: "Count only, no deletion",
+      hint: "Preview this view without clicking",
     },
     emptyTrash: {
       label: "Empty trash",
@@ -82,6 +82,20 @@ const en: Translations = {
     check: "I understand, and I am on the Google Photos view I intend to clean.",
     confirm: "Confirm & Start",
     cancel: "Cancel",
+  },
+  scope: {
+    actingOn: "Action scope: {view}",
+    library: "Library",
+    albums: "Albums",
+    album: "Album",
+    search: "Search",
+    trash: "Trash",
+    photo: "Photo",
+    memory: "Memory",
+    share: "Shared",
+    places: "Places",
+    collections: "Collections",
+    other: "This view ({path})",
   },
 }
 

--- a/src/extension/popup/i18n/locales/es.ts
+++ b/src/extension/popup/i18n/locales/es.ts
@@ -33,7 +33,7 @@ const es: Translations = {
     },
     dryRun: {
       label: "Modo prueba",
-      hint: "Solo contar, sin eliminar",
+      hint: "Previsualiza esta vista sin hacer clic",
     },
     emptyTrash: {
       label: "Vaciar papelera",
@@ -82,6 +82,20 @@ const es: Translations = {
     check: "Entiendo y estoy en la vista de Google Photos que quiero limpiar.",
     confirm: "Confirmar e iniciar",
     cancel: "Cancelar",
+  },
+  scope: {
+    actingOn: "Ámbito de acción: {view}",
+    library: "Biblioteca",
+    albums: "Álbumes",
+    album: "Álbum",
+    search: "Búsqueda",
+    trash: "Papelera",
+    photo: "Foto",
+    memory: "Recuerdo",
+    share: "Compartido",
+    places: "Lugares",
+    collections: "Colecciones",
+    other: "Esta vista ({path})",
   },
 }
 

--- a/src/extension/popup/i18n/locales/fr.ts
+++ b/src/extension/popup/i18n/locales/fr.ts
@@ -33,7 +33,7 @@ const fr: Translations = {
     },
     dryRun: {
       label: "Mode test",
-      hint: "Compter sans rien supprimer",
+      hint: "Aperçu de cette vue, sans clic",
     },
     emptyTrash: {
       label: "Vider la corbeille",
@@ -82,6 +82,20 @@ const fr: Translations = {
     check: "Je comprends, et je suis sur la vue Google Photos que je souhaite nettoyer.",
     confirm: "Confirmer et démarrer",
     cancel: "Annuler",
+  },
+  scope: {
+    actingOn: "Portée de l’action : {view}",
+    library: "Bibliothèque",
+    albums: "Albums",
+    album: "Album",
+    search: "Recherche",
+    trash: "Corbeille",
+    photo: "Photo",
+    memory: "Souvenir",
+    share: "Partagé",
+    places: "Lieux",
+    collections: "Collections",
+    other: "Cette vue ({path})",
   },
 }
 

--- a/src/extension/popup/i18n/locales/it.ts
+++ b/src/extension/popup/i18n/locales/it.ts
@@ -33,7 +33,7 @@ const it: Translations = {
     },
     dryRun: {
       label: "Prova a vuoto",
-      hint: "Conta senza eliminare",
+      hint: "Anteprima di questa vista, senza clic",
     },
     emptyTrash: {
       label: "Svuota cestino",
@@ -82,6 +82,20 @@ const it: Translations = {
     check: "Ho capito e sono nella vista Google Photos che intendo pulire.",
     confirm: "Conferma e avvia",
     cancel: "Annulla",
+  },
+  scope: {
+    actingOn: "Ambito di azione: {view}",
+    library: "Libreria",
+    albums: "Album",
+    album: "Album",
+    search: "Ricerca",
+    trash: "Cestino",
+    photo: "Foto",
+    memory: "Ricordo",
+    share: "Condiviso",
+    places: "Luoghi",
+    collections: "Raccolte",
+    other: "Questa vista ({path})",
   },
 }
 

--- a/src/extension/popup/i18n/locales/ja.ts
+++ b/src/extension/popup/i18n/locales/ja.ts
@@ -33,7 +33,7 @@ const ja: Translations = {
     },
     dryRun: {
       label: "テスト実行",
-      hint: "数えるだけで削除しない",
+      hint: "この画面をクリックせずに確認",
     },
     emptyTrash: {
       label: "ゴミ箱を空にする",
@@ -82,6 +82,20 @@ const ja: Translations = {
     check: "理解しました。削除対象の Google フォトの画面を表示しています。",
     confirm: "確認して開始",
     cancel: "キャンセル",
+  },
+  scope: {
+    actingOn: "操作対象: {view}",
+    library: "ライブラリ",
+    albums: "アルバム一覧",
+    album: "アルバム",
+    search: "検索",
+    trash: "ゴミ箱",
+    photo: "写真",
+    memory: "メモリー",
+    share: "共有",
+    places: "場所",
+    collections: "コレクション",
+    other: "この画面 ({path})",
   },
 }
 

--- a/src/extension/popup/i18n/locales/nl.ts
+++ b/src/extension/popup/i18n/locales/nl.ts
@@ -33,7 +33,7 @@ const nl: Translations = {
     },
     dryRun: {
       label: "Proefrit",
-      hint: "Alleen tellen, niet verwijderen",
+      hint: "Bekijk deze weergave zonder te klikken",
     },
     emptyTrash: {
       label: "Prullenbak legen",
@@ -82,6 +82,20 @@ const nl: Translations = {
     check: "Ik begrijp het en bevind me in de Google Photos-weergave die ik wil opschonen.",
     confirm: "Bevestigen en starten",
     cancel: "Annuleren",
+  },
+  scope: {
+    actingOn: "Actiebereik: {view}",
+    library: "Bibliotheek",
+    albums: "Albums",
+    album: "Album",
+    search: "Zoeken",
+    trash: "Prullenbak",
+    photo: "Foto",
+    memory: "Herinnering",
+    share: "Gedeeld",
+    places: "Plaatsen",
+    collections: "Collecties",
+    other: "Deze weergave ({path})",
   },
 }
 

--- a/src/extension/popup/i18n/locales/pt.ts
+++ b/src/extension/popup/i18n/locales/pt.ts
@@ -33,7 +33,7 @@ const pt: Translations = {
     },
     dryRun: {
       label: "Simulação",
-      hint: "Apenas contar, sem excluir",
+      hint: "Pré-visualiza esta vista sem clicar",
     },
     emptyTrash: {
       label: "Esvaziar lixeira",
@@ -82,6 +82,20 @@ const pt: Translations = {
     check: "Entendo e estou na visualização do Google Photos que pretendo limpar.",
     confirm: "Confirmar e iniciar",
     cancel: "Cancelar",
+  },
+  scope: {
+    actingOn: "Âmbito da ação: {view}",
+    library: "Biblioteca",
+    albums: "Álbuns",
+    album: "Álbum",
+    search: "Pesquisa",
+    trash: "Lixeira",
+    photo: "Foto",
+    memory: "Memória",
+    share: "Partilhado",
+    places: "Locais",
+    collections: "Coleções",
+    other: "Esta vista ({path})",
   },
 }
 

--- a/src/extension/popup/i18n/locales/zh.ts
+++ b/src/extension/popup/i18n/locales/zh.ts
@@ -33,7 +33,7 @@ const zh: Translations = {
     },
     dryRun: {
       label: "试运行",
-      hint: "仅计数,不删除",
+      hint: "预览当前视图，不点击任何内容",
     },
     emptyTrash: {
       label: "清空回收站",
@@ -82,6 +82,20 @@ const zh: Translations = {
     check: "我理解，并且我正位于要清理的 Google 相册视图。",
     confirm: "确认并开始",
     cancel: "取消",
+  },
+  scope: {
+    actingOn: "操作范围：{view}",
+    library: "图库",
+    albums: "相册",
+    album: "相册",
+    search: "搜索",
+    trash: "回收站",
+    photo: "照片",
+    memory: "回忆",
+    share: "共享",
+    places: "地点",
+    collections: "合集",
+    other: "当前视图（{path}）",
   },
 }
 

--- a/src/extension/popup/i18n/types.ts
+++ b/src/extension/popup/i18n/types.ts
@@ -61,6 +61,22 @@ export interface Translations {
   notes: {
     navigateFirst: string
   }
+  scope: {
+    /** "Action scope: {view}" */
+    actingOn: string
+    library: string
+    albums: string
+    album: string
+    search: string
+    trash: string
+    photo: string
+    memory: string
+    share: string
+    places: string
+    collections: string
+    /** "This view ({path})" */
+    other: string
+  }
 }
 
 /** Browser-language → locale-code mapping for first-run auto-detect. */

--- a/src/extension/popup/popup.css
+++ b/src/extension/popup/popup.css
@@ -745,6 +745,18 @@ body {
 }
 .btn-danger:hover { background: var(--danger-hover); }
 
+/* ─── Action scope ────────────────────────────────────────────── */
+.scope {
+  text-align: center;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+  padding: 6px 10px;
+  background: var(--bg-note);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+}
+
 /* ─── Note ────────────────────────────────────────────────────── */
 .note {
   text-align: center;

--- a/src/extension/popup/popup.html
+++ b/src/extension/popup/popup.html
@@ -46,6 +46,11 @@
       <span class="status-text" id="status-text" data-i18n="status.ready">Ready</span>
     </div>
 
+    <!-- ─── Current-view action scope (GPDT-ENTER) ──────────────── -->
+    <p class="scope hidden" id="scope" role="status">
+      <span id="scope-label"></span>
+    </p>
+
     <!-- ─── Error banner ────────────────────────────────────────── -->
     <div class="error hidden" id="error" role="alert">
       <span class="error-icon" id="error-icon" aria-hidden="true"></span>

--- a/src/extension/popup/popup.ts
+++ b/src/extension/popup/popup.ts
@@ -3,6 +3,11 @@ import { formatElapsed } from '../../core/utils'
 import { buildDiagnosticIssueUrl, type DiagnosticBlob } from '../../core/diagnostics'
 import { verifyLicense } from '../../core/license'
 import { TRASH_URL } from '../../core/empty-trash-baton'
+import {
+  admitSurface,
+  isSupportedPhotosUrl,
+  type PhotosView,
+} from '../../core/surface'
 import { storageGet, storageSet, tabsCreate, tabsQuery, tabsSendMessage } from '../api'
 import type { PhotoFilter, PhotoType } from '../../core/photo-filter'
 import { ACTIVE_STATUSES, TERMINAL_STATUSES, type RunStatus } from '../../core/status'
@@ -41,6 +46,8 @@ const resumeBtn       = document.getElementById('resume-btn')     as HTMLButtonE
 const stopBtn         = document.getElementById('stop-btn')       as HTMLButtonElement
 const statusDot       = document.getElementById('status-dot')     as HTMLElement
 const statusText      = document.getElementById('status-text')    as HTMLElement
+const scopeEl         = document.getElementById('scope')          as HTMLElement
+const scopeLabel      = document.getElementById('scope-label')    as HTMLElement
 const errorBar        = document.getElementById('error')          as HTMLElement
 const errorText       = document.getElementById('error-text')     as HTMLElement
 const progressFill    = document.getElementById('progress-fill')  as HTMLElement
@@ -85,6 +92,8 @@ let startedAt = 0
 let elapsedTimer: ReturnType<typeof setInterval> | null = null
 let proActive = false
 let lastReport: { total: number; labels: string[] } | null = null
+let currentView: PhotosView | null = null
+let surfaceReady = false
 
 const CONSENT_KEY = 'gpdt_consent_v3'
 const PRO_TOKEN_KEY = 'proToken'
@@ -143,6 +152,7 @@ function applyLocale(code: LocaleCode): void {
   renderLangMenu()
   refreshStatusLabel()
   renderNote()
+  renderScope()
   licenseInput.placeholder = t('settings.license.placeholder')
   storageSet({ locale: code }).catch(err =>
     console.warn(`${LOG} could not persist locale:`, err),
@@ -308,7 +318,7 @@ licenseBtn.addEventListener('click', async () => {
 
 const sendToContent = async (message: Record<string, unknown>): Promise<unknown> => {
   const [tab] = await tabsQuery({ active: true, currentWindow: true })
-  if (!tab?.id || !tab.url?.includes('photos.google.com')) {
+  if (!tab?.id || !isSupportedPhotosUrl(tab.url)) {
     showNote('notes.navigateFirst')
     return null
   }
@@ -375,6 +385,49 @@ const showNote = (key: string): void => {
   noteEl.classList.remove('hidden')
 }
 const hideNote = (): void => { noteEl.classList.add('hidden') }
+
+function viewLabel(view: PhotosView): string {
+  if (view.kind === 'other') return t('scope.other', { path: view.path })
+  const kind = t(`scope.${view.kind}`)
+  return view.target ? `${kind} · ${view.target}` : kind
+}
+
+function renderScope(): void {
+  if (!currentView) {
+    scopeEl.classList.add('hidden')
+    scopeLabel.textContent = ''
+    return
+  }
+  scopeLabel.textContent = t('scope.actingOn', { view: viewLabel(currentView) })
+  scopeEl.classList.remove('hidden')
+}
+
+async function refreshSurfaceAdmission(): Promise<void> {
+  try {
+    const [tab] = await tabsQuery({ active: true, currentWindow: true })
+    const admission = admitSurface(tab?.url)
+    if (!admission.ok) {
+      surfaceReady = false
+      currentView = null
+      startBtn.disabled = true
+      renderScope()
+      showNote('notes.navigateFirst')
+      return
+    }
+    surfaceReady = true
+    currentView = admission.view
+    if (uiState === 'idle') startBtn.disabled = false
+    renderScope()
+    hideNote()
+  } catch (err) {
+    console.warn(`${LOG} surface admission failed:`, err)
+    surfaceReady = false
+    currentView = null
+    startBtn.disabled = true
+    renderScope()
+    showNote('notes.navigateFirst')
+  }
+}
 const showError = (msg: string): void => { errorText.textContent = msg; errorBar.classList.remove('hidden') }
 const hideError = (): void => { errorBar.classList.add('hidden') }
 
@@ -434,7 +487,7 @@ const readFilter = (): PhotoFilter => {
 }
 
 startBtn.addEventListener('click', async () => {
-  if (uiState !== 'idle') return
+  if (uiState !== 'idle' || !surfaceReady) return
   startBtn.disabled = true
   try {
     const opts = {
@@ -456,7 +509,7 @@ startBtn.addEventListener('click', async () => {
 
     await doStart(opts)
   } finally {
-    startBtn.disabled = false
+    startBtn.disabled = !surfaceReady || uiState !== 'idle'
   }
 })
 
@@ -685,5 +738,6 @@ void (async () => {
   }
   refreshDryRunDependentFields()
   void refreshProState()
+  void refreshSurfaceAdmission()
   void queryInitialStatus()
 })()

--- a/src/standalone/inject.ts
+++ b/src/standalone/inject.ts
@@ -2,11 +2,16 @@
  * Google Photos Delete Tool — Standalone injection script.
  * Paste the built IIFE into DevTools console on photos.google.com.
  * Same shared panel + runner as the userscript (dev artifact).
+ *
+ * GPDT-ENTER: refuse to activate off photos.google.com.
  */
 import { PageRunner } from '../core/page-runner'
 import { mountPanel } from '../ui/panel/panel'
+import { activateLocalSurface } from '../core/surface'
 
-const runner = new PageRunner()
-void runner.maybeRunPendingEmptyTrash()
-const host = document.body ?? document.documentElement
-mountPanel(host, runner)
+activateLocalSurface(window.location.href, () => {
+  const runner = new PageRunner()
+  void runner.maybeRunPendingEmptyTrash()
+  const host = document.body ?? document.documentElement
+  mountPanel(host, runner)
+})

--- a/src/ui/panel/panel.ts
+++ b/src/ui/panel/panel.ts
@@ -5,6 +5,7 @@
  * i18n'd surface with the same controls (parity by contract, not code).
  */
 import type { PageRunner, PanelRunOptions } from '../../core/page-runner'
+import { admitSurface, describePhotosView } from '../../core/surface'
 import { formatElapsed, formatEta } from '../../core/utils'
 import { ACTIVE_STATUSES } from '../../core/status'
 import type { Progress, RunStatus } from '../../core'
@@ -95,12 +96,13 @@ export function mountPanel(container: HTMLElement, runner: PageRunner): void {
         <button class="gpdt-ghost" id="gpdt-close" title="Close">✕</button>
       </span>
     </div>
+    <div class="gpdt-note" id="gpdt-scope"></div>
     <div class="gpdt-row">
       <label for="gpdt-max">Photos per batch</label>
       <input type="number" id="gpdt-max" value="500" min="1" max="2000" step="50" style="width:110px" />
     </div>
     <div class="gpdt-row">
-      <label for="gpdt-dryrun">Dry run (count only)</label>
+      <label for="gpdt-dryrun">Dry run (count this view, no clicks)</label>
       <input type="checkbox" id="gpdt-dryrun" style="accent-color:#3b82f6" />
     </div>
     <div class="gpdt-row">
@@ -182,6 +184,12 @@ export function mountPanel(container: HTMLElement, runner: PageRunner): void {
   const consentPermanent = $<HTMLElement>('gpdt-consent-permanent')
   const copyBtn = $<HTMLButtonElement>('gpdt-copy')
   const exportBtn = $<HTMLButtonElement>('gpdt-export')
+  const scopeEl = $<HTMLElement>('gpdt-scope')
+
+  const admission = admitSurface(window.location.href)
+  scopeEl.textContent = admission.ok
+    ? `Action scope: ${describePhotosView(admission.view)}`
+    : 'Open photos.google.com first.'
 
   let pro = false
   let pendingStart: PanelRunOptions | null = null

--- a/src/userscript/google-photos-delete.user.ts
+++ b/src/userscript/google-photos-delete.user.ts
@@ -2,15 +2,17 @@
  * Google Photos Delete Tool — Userscript (Tampermonkey / Violentmonkey /
  * Greasemonkey). Thin mount: the shared control panel + in-page runner.
  * The metadata header is injected at build time by scripts/build.ts.
+ *
+ * GPDT-ENTER: refuse to activate off photos.google.com even if the
+ * manager's @match is bypassed.
  */
 import { PageRunner } from '../core/page-runner'
 import { mountPanel } from '../ui/panel/panel'
+import { activateLocalSurface } from '../core/surface'
 
-const runner = new PageRunner()
-
-// Consume a pending "empty trash" flag on /trash (set by a previous run
-// that finished with "Empty trash afterwards" enabled).
-void runner.maybeRunPendingEmptyTrash()
-
-const host = document.body ?? document.documentElement
-mountPanel(host, runner)
+activateLocalSurface(window.location.href, () => {
+  const runner = new PageRunner()
+  void runner.maybeRunPendingEmptyTrash()
+  const host = document.body ?? document.documentElement
+  mountPanel(host, runner)
+})

--- a/tests/i18n.test.ts
+++ b/tests/i18n.test.ts
@@ -60,6 +60,8 @@ describe('LOCALES', () => {
       'settings.language.label', 'settings.language.trigger',
       'actions.start', 'actions.pause', 'actions.resume', 'actions.stop',
       'notes.navigateFirst',
+      'scope.actingOn', 'scope.library', 'scope.album', 'scope.trash',
+      'scope.other',
     ]
     for (const locale of LOCALES) {
       setLocale(locale.code)
@@ -184,6 +186,24 @@ describe('tHtml() — verbatim interpolation', () => {
   it('returns the key unchanged for missing translations', () => {
     expect(tHtml('does.not.exist', { x: '<b>1</b>' })).toBe('does.not.exist')
   })
+})
+
+describe('every locale carries the {view} placeholder for the action scope', () => {
+  for (const locale of LOCALES) {
+    it(`locale "${locale.code}" includes {view} in scope.actingOn`, () => {
+      setLocale(locale.code)
+      expect(t('scope.actingOn')).toContain('{view}')
+    })
+  }
+})
+
+describe('every locale carries the {path} placeholder for other views', () => {
+  for (const locale of LOCALES) {
+    it(`locale "${locale.code}" includes {path} in scope.other`, () => {
+      setLocale(locale.code)
+      expect(t('scope.other')).toContain('{path}')
+    })
+  }
 })
 
 describe('every locale carries the {url} placeholder for the note', () => {

--- a/tests/surface.test.ts
+++ b/tests/surface.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  SUPPORTED_HOST,
+  SUPPORTED_ORIGIN,
+  SUPPORTED_MATCH_PATTERN,
+  isSupportedPhotosUrl,
+  identifyPhotosView,
+  admitSurface,
+  activateLocalSurface,
+  describePhotosView,
+} from '../src/core/surface'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const read = (p: string): string => readFileSync(resolve(root, p), 'utf-8')
+
+describe('isSupportedPhotosUrl', () => {
+  it('admits exact https://photos.google.com URLs', () => {
+    expect(isSupportedPhotosUrl('https://photos.google.com/')).toBe(true)
+    expect(isSupportedPhotosUrl('https://photos.google.com')).toBe(true)
+    expect(isSupportedPhotosUrl('https://photos.google.com/u/0/album/abc')).toBe(true)
+    expect(isSupportedPhotosUrl('https://photos.google.com/search/foo?authuser=1')).toBe(true)
+    expect(isSupportedPhotosUrl('https://PHOTOS.GOOGLE.COM/u/0/')).toBe(true)
+    expect(isSupportedPhotosUrl('https://photos.google.com:443/')).toBe(true)
+  })
+
+  it('rejects missing, empty, and unparseable input', () => {
+    expect(isSupportedPhotosUrl(undefined)).toBe(false)
+    expect(isSupportedPhotosUrl(null)).toBe(false)
+    expect(isSupportedPhotosUrl('')).toBe(false)
+    expect(isSupportedPhotosUrl('photos.google.com')).toBe(false)
+    expect(isSupportedPhotosUrl('/u/0/')).toBe(false)
+    expect(isSupportedPhotosUrl('not a url')).toBe(false)
+  })
+
+  it('rejects lookalike hosts and weaker schemes — the substring bug', () => {
+    expect(isSupportedPhotosUrl('https://photos.google.com.evil.com/')).toBe(false)
+    expect(isSupportedPhotosUrl('https://evil.com/photos.google.com')).toBe(false)
+    expect(isSupportedPhotosUrl('https://evil.com/?q=photos.google.com')).toBe(false)
+    expect(isSupportedPhotosUrl('https://notphotos.google.com/')).toBe(false)
+    expect(isSupportedPhotosUrl('https://www.photos.google.com/')).toBe(false)
+    expect(isSupportedPhotosUrl('https://photos.google.com./')).toBe(false)
+    expect(isSupportedPhotosUrl('http://photos.google.com/')).toBe(false)
+    expect(isSupportedPhotosUrl('https://photos.google.com:8443/')).toBe(false)
+    expect(isSupportedPhotosUrl('https://user:pass@photos.google.com/')).toBe(false)
+    expect(isSupportedPhotosUrl('ftp://photos.google.com/')).toBe(false)
+  })
+})
+
+describe('identifyPhotosView', () => {
+  it('returns null on an unsupported URL', () => {
+    expect(identifyPhotosView('https://example.com/')).toBeNull()
+    expect(identifyPhotosView(undefined)).toBeNull()
+  })
+
+  it('treats / and /u/<n>/ as the library', () => {
+    expect(identifyPhotosView('https://photos.google.com/')).toEqual({
+      kind: 'library',
+      path: '/',
+    })
+    expect(identifyPhotosView('https://photos.google.com/u/0')).toEqual({
+      kind: 'library',
+      path: '/',
+      account: '0',
+    })
+    expect(identifyPhotosView('https://photos.google.com/u/1/')).toEqual({
+      kind: 'library',
+      path: '/',
+      account: '1',
+    })
+  })
+
+  it('classifies known current-view families, including /u/<n>/ prefixes', () => {
+    expect(identifyPhotosView('https://photos.google.com/albums')?.kind).toBe('albums')
+    expect(identifyPhotosView('https://photos.google.com/u/0/album/AF1QipXxx')).toEqual({
+      kind: 'album',
+      path: '/album/AF1QipXxx',
+      account: '0',
+      target: 'AF1QipXxx',
+    })
+    expect(identifyPhotosView('https://photos.google.com/search/hello%20world')?.target).toBe('hello world')
+    expect(identifyPhotosView('https://photos.google.com/u/0/trash')?.kind).toBe('trash')
+    expect(identifyPhotosView('https://photos.google.com/u/0/trash/item')?.kind).toBe('trash')
+    expect(identifyPhotosView('https://photos.google.com/photo/abc')?.kind).toBe('photo')
+    expect(identifyPhotosView('https://photos.google.com/memory/xyz')?.kind).toBe('memory')
+    expect(identifyPhotosView('https://photos.google.com/share/tok')?.kind).toBe('share')
+    expect(identifyPhotosView('https://photos.google.com/sharing/tok')?.kind).toBe('share')
+    expect(identifyPhotosView('https://photos.google.com/places')?.kind).toBe('places')
+    expect(identifyPhotosView('https://photos.google.com/collections')?.kind).toBe('collections')
+  })
+
+  it('does not treat a path that merely contains "trash" as trash', () => {
+    const view = identifyPhotosView('https://photos.google.com/trashbin')
+    expect(view?.kind).toBe('other')
+    expect(view?.path).toBe('/trashbin')
+  })
+})
+
+describe('admitSurface / activateLocalSurface', () => {
+  it('admits a supported view and refuses anything else', () => {
+    const ok = admitSurface('https://photos.google.com/u/0/search/cats')
+    expect(ok.ok).toBe(true)
+    if (ok.ok) expect(ok.view.kind).toBe('search')
+    expect(admitSurface('https://example.com/')).toEqual({ ok: false, reason: 'unsupported-url' })
+  })
+
+  it('mounts only on an admitted surface', () => {
+    const mount = vi.fn()
+    expect(activateLocalSurface('https://evil.com/?q=photos.google.com', mount)).toBe('refused')
+    expect(mount).not.toHaveBeenCalled()
+    expect(activateLocalSurface('https://photos.google.com/u/0/', mount)).toBe('activated')
+    expect(mount).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('describePhotosView', () => {
+  it('names the current view as the action scope', () => {
+    expect(describePhotosView({ kind: 'library', path: '/' })).toBe('Library')
+    expect(describePhotosView({
+      kind: 'album',
+      path: '/album/AF1',
+      target: 'AF1',
+    })).toBe('Album · AF1')
+    expect(describePhotosView({ kind: 'other', path: '/utilities' })).toBe('/utilities')
+  })
+})
+
+describe('GPDT-ENTER constants stay the single host writer', () => {
+  it('names the exact photos.google.com origin', () => {
+    expect(SUPPORTED_HOST).toBe('photos.google.com')
+    expect(SUPPORTED_ORIGIN).toBe('https://photos.google.com')
+    expect(SUPPORTED_MATCH_PATTERN).toBe('https://photos.google.com/*')
+  })
+
+  it('manifest host and content-script matches equal the authority', () => {
+    const manifest = JSON.parse(read('src/extension/manifest.json')) as {
+      host_permissions: string[]
+      content_scripts: Array<{ matches: string[] }>
+    }
+    expect(manifest.host_permissions).toEqual([SUPPORTED_MATCH_PATTERN])
+    expect(manifest.content_scripts[0]?.matches).toEqual([SUPPORTED_MATCH_PATTERN])
+  })
+})

--- a/tests/ui-wiring.test.ts
+++ b/tests/ui-wiring.test.ts
@@ -75,3 +75,34 @@ describe('consent storage key contract', () => {
     expect(new Set([popupKey, contentKey, runnerKey]).size).toBe(1)
   })
 })
+
+describe('GPDT-ENTER surface contract', () => {
+  it('popup admits tabs via isSupportedPhotosUrl, not a substring includes', () => {
+    const popupTs = read('src/extension/popup/popup.ts')
+    expect(popupTs).toContain('isSupportedPhotosUrl')
+    expect(popupTs).not.toMatch(/includes\(['"]photos\.google\.com['"]\)/)
+  })
+
+  it('userscript and standalone activate only through activateLocalSurface', () => {
+    const userscript = read('src/userscript/google-photos-delete.user.ts')
+    const standalone = read('src/standalone/inject.ts')
+    expect(userscript).toContain('activateLocalSurface')
+    expect(standalone).toContain('activateLocalSurface')
+  })
+
+  it('popup and panel offer a click-free dry-run control', () => {
+    const popupHtml = read('src/extension/popup/popup.html')
+    const panelTs = read('src/ui/panel/panel.ts')
+    expect(popupHtml).toMatch(/id="dry-run"/)
+    expect(panelTs).toMatch(/id="gpdt-dryrun"/)
+  })
+
+  it('popup names the current view as the action scope', () => {
+    const popupHtml = read('src/extension/popup/popup.html')
+    const popupTs = read('src/extension/popup/popup.ts')
+    expect(popupHtml).toMatch(/id="scope"/)
+    expect(popupTs).toContain('admitSurface')
+    expect(popupTs).toContain('scope.actingOn')
+  })
+})
+


### PR DESCRIPTION
## Identity

- **identity:** `GPDT-ENTER` — Enter a supported, locally controlled surface
- **fate:** `live` (as declared)
- **destination revision:** `5565646b85ae0e755d826271ec6c0673706103be` (`docs/vision.md` + `docs/capabilities.md` at master)
- **candidate_sha:** `8c83e261dc4ff2ead3be576c69b0f1ae9586afe7`

## Write-set

One identity's source files for `GPDT-ENTER`:

- `src/core/surface.ts` — single host/view admission authority (new)
- `src/core/index.ts` — re-export the surface contract
- extension popup/content, userscript, standalone, panel — consume that authority
- `scripts/build.ts` / `scripts/verify.ts` — userscript `@match` and manifest matches bind to the same pattern
- local tests: `tests/surface.test.ts` (new), `tests/ui-wiring.test.ts`, `tests/i18n.test.ts`

Does not edit `docs/vision.md` or `docs/capabilities.md`. Does not perform live Google Photos deletes.

## Done-when (oracle, named at source)

1. Extension / userscript activate only for `https://photos.google.com` — exact host, reject lookalikes, `http`, credentials, and non-default ports. Popup no longer uses substring `includes('photos.google.com')`.
2. The chosen current view is identified as the action scope (`library` / `album` / `search` / `trash` / …, including `/u/<n>/` prefixes) and shown on both surfaces (popup scope line + in-page panel scope line).
3. A click-free dry-run is offered on both surfaces before destructive work; dry-run still does not click and does not require consent (`tests/page-runner.test.ts`, `tests/delete-engine.test.ts`).

## Evidence layer

Source / local tests. Not CI, not landed, not live-browser, not store.

Run locally at `candidate_sha` (`8c83e261dc4ff2ead3be576c69b0f1ae9586afe7`, working tree clean):

- `bun run typecheck` — pass
- `bun run lint` — pass
- `bun run test` — 190 passed (17 files)
- `bun run build` — pass (Chrome + Firefox extension, standalone, userscript)
- `bun run verify` — pass (all artifacts consistent; userscript `@match` and manifest matches equal `https://photos.google.com/*`)

No live Google Photos session; no destructive action was performed.

## Recovery

Revert this PR / drop this branch. No data migration, no live writer, no store publish.

## Next action

A different session reviews this SHA independently. Do not merge from this Worker. The forge waits.

- base: `master@5565646b85ae0e755d826271ec6c0673706103be`
