### PR TITLE
feat(core): pack-owned scroll container and dialog selectors (GPDT-OBSERVE)

### DIFF
--- a/scripts/verify.ts
+++ b/scripts/verify.ts
@@ -132,7 +132,9 @@ for (const dir of ['extension', 'extension-firefox']) {
 // ─── Selector pack integrity ────────────────────────────────────
 {
   const pack = JSON.parse(read('src/selector-packs/pack-v1.json'))
-  check(pack.version === 2, 'selector pack version == 2 (photoTypes present)')
+  const selectors = pack.selectors ?? {}
+  check(pack.version === 3, 'selector pack version == 3 (scroll container + dialogs)')
+  check(!!selectors.scrollContainer && !!selectors.dialog, 'pack identifies scroll container and dialogs')
   check(!!pack.photoTypes?.photo?.length && !!pack.photoTypes?.screenshot?.length, 'pack photoTypes keyword lists non-empty')
 }
 

--- a/src/core/browser-dom.ts
+++ b/src/core/browser-dom.ts
@@ -5,7 +5,7 @@
  * the only place where DOM APIs meet the engine. Everything else in
  * `core/` stays pure and unit-testable.
  */
-import { SELECTOR_DEFS, queryOne, queryAll, findDeleteToolbarButton, findConfirmDialog, findConfirmButton } from './selectors'
+import { SELECTOR_DEFS, queryOne, queryAll, queryScrollable, findDeleteToolbarButton, findConfirmDialog, findConfirmButton } from './selectors'
 import { sleep } from './utils'
 import type { ClickTarget, EngineDom, PhotoTile, ScrollTarget } from './dom-adapter'
 
@@ -37,8 +37,10 @@ function wrapScrollTarget(el: HTMLElement): ScrollTarget {
 }
 
 function findScrollTarget(): ScrollTarget | null {
-  const container = queryOne(SELECTOR_DEFS.photoContainer) as HTMLElement | null
-  if (container && container.scrollHeight > container.clientHeight + 1) {
+  // The gallery scroller is pack-owned (`scrollContainer` def): a DOM
+  // drift is a pack data patch. Unknown DOM returns null (fail closed).
+  const container = queryScrollable(SELECTOR_DEFS.scrollContainer)
+  if (container) {
     return wrapScrollTarget(container)
   }
   const docScroll = (typeof document !== 'undefined' && (document.scrollingElement || document.documentElement)) as HTMLElement | null

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -3,6 +3,8 @@ export {
   SELECTOR_DEFS,
   queryOne,
   queryAll,
+  queryAllUnion,
+  queryScrollable,
   type SelectorDef,
   DELETE_KEYWORDS,
   CANCEL_KEYWORDS,

--- a/src/core/selector-pack.ts
+++ b/src/core/selector-pack.ts
@@ -19,7 +19,15 @@ export const PACK_VERSION: number = packJson.version
 
 export interface SelectorPack {
   version: number
-  selectors: Record<'counter' | 'checkbox' | 'checkboxChecked' | 'photoContainer', SelectorDef>
+  selectors: Record<
+    | 'counter'
+    | 'checkbox'
+    | 'checkboxChecked'
+    | 'photoContainer'
+    | 'scrollContainer'
+    | 'dialog',
+    SelectorDef
+  >
   actionButtons: {
     toolbarDelete: string[]
     emptyTrash: string[]

--- a/src/core/selectors.ts
+++ b/src/core/selectors.ts
@@ -16,8 +16,15 @@ import { diagnostics } from './diagnostics'
 export type { SelectorDef }
 export { PACK_VERSION } from './selector-pack'
 
-export const SELECTOR_DEFS: Record<'counter' | 'checkbox' | 'checkboxChecked' | 'photoContainer', SelectorDef> =
-  PACK.selectors
+export const SELECTOR_DEFS: Record<
+  | 'counter'
+  | 'checkbox'
+  | 'checkboxChecked'
+  | 'photoContainer'
+  | 'scrollContainer'
+  | 'dialog',
+  SelectorDef
+> = PACK.selectors
 
 export const TOOLBAR_DELETE_CANDIDATES: readonly string[] = Object.freeze([...PACK.actionButtons.toolbarDelete])
 export const EMPTY_TRASH_CANDIDATES: readonly string[] = Object.freeze([...PACK.actionButtons.emptyTrash])
@@ -92,6 +99,67 @@ export function queryAll(def: SelectorDef, root: ParentNode = document): Element
 
   diagnostics.recordSelector(def.name, 'none')
   return []
+}
+
+/**
+ * Query all elements matching the def's primary or any fallback
+ * selector, deduplicated (union semantics). Unlike `queryAll`, a
+ * primary hit does not suppress fallback matches — dialog discovery
+ * must consider the whole pack-owned selector list. Records the
+ * observed match into diagnostics.
+ */
+export function queryAllUnion<T extends Element = Element>(
+  def: SelectorDef,
+  root: ParentNode = document,
+): T[] {
+  const selectors = [def.primary, ...def.fallbacks]
+  const seen = new Set<Element>()
+  const out: T[] = []
+  let firstMatch: string | null = null
+  for (const sel of selectors) {
+    for (const el of root.querySelectorAll<T>(sel)) {
+      if (seen.has(el)) continue
+      seen.add(el)
+      out.push(el)
+      if (firstMatch === null) firstMatch = sel
+    }
+  }
+  if (out.length > 0) {
+    diagnostics.recordSelector(
+      def.name,
+      firstMatch === def.primary ? 'primary' : 'fallback',
+      firstMatch === def.primary ? undefined : (firstMatch ?? undefined),
+    )
+    return out
+  }
+  diagnostics.recordSelector(def.name, 'none')
+  return []
+}
+
+/**
+ * Find the first element matching the def (primary first, then each
+ * fallback) that actually scrolls (`scrollHeight > clientHeight + 1`),
+ * so a non-scrollable ancestor matched by a class never shadows the
+ * real gallery scroller. Unknown DOM returns null. Records the observed
+ * match into diagnostics.
+ */
+export function queryScrollable(def: SelectorDef, root: ParentNode = document): HTMLElement | null {
+  const selectors = [def.primary, ...def.fallbacks]
+  for (let i = 0; i < selectors.length; i++) {
+    const sel = selectors[i]
+    for (const el of root.querySelectorAll<HTMLElement>(sel)) {
+      if (el.scrollHeight > el.clientHeight + 1) {
+        diagnostics.recordSelector(
+          def.name,
+          i === 0 ? 'primary' : 'fallback',
+          i === 0 ? undefined : sel,
+        )
+        return el
+      }
+    }
+  }
+  diagnostics.recordSelector(def.name, 'none')
+  return null
 }
 
 // ─── Text normalization & keyword matching ────────────────────────
@@ -170,7 +238,7 @@ function isVisible(el: Element): boolean {
 }
 
 function isInsideDialog(el: Element): boolean {
-  return !!el.closest('[role="dialog"], [role="alertdialog"], [aria-modal="true"]')
+  return !!el.closest([SELECTOR_DEFS.dialog.primary, ...SELECTOR_DEFS.dialog.fallbacks].join(', '))
 }
 
 /** Score a button: higher = more likely the destructive action. */
@@ -269,11 +337,9 @@ export function isTrashEmpty(): boolean {
  * visible one (highest z-index) when multiple are open.
  */
 export function findConfirmDialog(): HTMLElement | null {
-  const candidates = [
-    ...document.querySelectorAll<HTMLElement>(
-      '[role="dialog"], [role="alertdialog"], [aria-modal="true"]',
-    ),
-  ].filter(isVisible)
+  // Dialogs come from the versioned pack (union of primary + fallbacks)
+  // so a layout drift is a pack data patch, never code surgery.
+  const candidates = queryAllUnion<HTMLElement>(SELECTOR_DEFS.dialog).filter(isVisible)
   if (candidates.length === 0) return null
   if (candidates.length === 1) return candidates[0]
   candidates.sort((a, b) => {

--- a/src/selector-packs/pack-v1.json
+++ b/src/selector-packs/pack-v1.json
@@ -1,6 +1,6 @@
 {
-  "version": 2,
-  "_comment": "Versioned, data-driven Google Photos DOM pack. Primaries are empirical selectors validated against the live UI at release time (see docs/RELEASE_GATE.md); the live gate may promote ARIA/role selectors in a later pack without code changes. A drift fix is a data patch, never code surgery. Photo-type label keywords added in v2 (first-token matching).",
+  "version": 3,
+  "_comment": "Versioned, data-driven Google Photos DOM pack. Primaries are empirical selectors validated against the live UI at release time (see docs/RELEASE_GATE.md); the live gate may promote ARIA/role selectors in a later pack without code changes. A drift fix is a data patch, never code surgery. Photo-type label keywords added in v2 (first-token matching). v3 adds pack-owned scroll-container and dialog selectors so every Google Photos observation (media tiles, selection state, scroll container, dialogs, destructive candidates) is data-driven and fail-closed.",
   "selectors": {
     "counter": {
       "name": "Selected photo count",
@@ -34,6 +34,23 @@
         "[role=\"main\"]",
         "[role=\"list\"]",
         "[role=\"grid\"]"
+      ]
+    },
+    "scrollContainer": {
+      "name": "Gallery scroll container",
+      "primary": ".yDSiEe.uGCjIb.zcLWac",
+      "fallbacks": [
+        ".Mfixef",
+        "[role=\"grid\"]",
+        "[role=\"main\"]"
+      ]
+    },
+    "dialog": {
+      "name": "Confirmation dialog",
+      "primary": "[role=\"dialog\"]",
+      "fallbacks": [
+        "[role=\"alertdialog\"]",
+        "[aria-modal=\"true\"]"
       ]
     }
   },

--- a/tests/selector-pack.test.ts
+++ b/tests/selector-pack.test.ts
@@ -4,8 +4,8 @@ import { SELECTOR_DEFS, TRASH_EMPTY_SIGNALS } from '../src/core/selectors'
 
 describe('selector pack', () => {
   it('ships a versioned data pack', () => {
-    expect(PACK_VERSION).toBe(2)
-    expect(PACK.version).toBe(2)
+    expect(PACK_VERSION).toBe(3)
+    expect(PACK.version).toBe(3)
   })
 
   it('defines every core selector', () => {
@@ -13,6 +13,11 @@ describe('selector pack', () => {
     expect(SELECTOR_DEFS.checkbox.primary).toContain('aria-checked')
     expect(SELECTOR_DEFS.checkboxChecked.primary).toContain('aria-checked')
     expect(SELECTOR_DEFS.photoContainer.fallbacks.length).toBeGreaterThan(0)
+    expect(SELECTOR_DEFS.scrollContainer.primary).toBe('.yDSiEe.uGCjIb.zcLWac')
+    expect(SELECTOR_DEFS.scrollContainer.fallbacks.length).toBeGreaterThan(0)
+    expect(SELECTOR_DEFS.dialog.primary).toBe('[role="dialog"]')
+    expect(SELECTOR_DEFS.dialog.fallbacks).toContain('[role="alertdialog"]')
+    expect(SELECTOR_DEFS.dialog.fallbacks).toContain('[aria-modal="true"]')
   })
 
   it('keeps destructive keyword lists non-empty and distinct', () => {

--- a/tests/selectors.test.ts
+++ b/tests/selectors.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, afterEach } from 'vitest'
 import {
   normalizeText,
   containsAnyKeyword,
@@ -6,6 +6,10 @@ import {
   CANCEL_KEYWORDS,
   EMPTY_TRASH_PHRASES,
   findConfirmButton,
+  findConfirmDialog,
+  queryAllUnion,
+  queryScrollable,
+  SELECTOR_DEFS,
 } from '../src/core/selectors'
 
 describe('normalizeText', () => {
@@ -227,5 +231,90 @@ describe('findConfirmButton', () => {
   it('fails closed instead of guessing the last non-cancel button', () => {
     const dialog = dialogWithButtons(['Cancel', 'OK'])
     expect(findConfirmButton(dialog)).toBeNull()
+  })
+})
+
+// ─── Pack-owned scroll container & dialogs ─────────────────────────
+
+function fakeRoot(matches: Record<string, unknown[]>): ParentNode {
+  return {
+    querySelectorAll: (sel: string) => matches[sel] ?? [],
+  } as unknown as ParentNode
+}
+
+function elWith(overrides: Record<string, unknown> = {}): HTMLElement {
+  return {
+    getAttribute: () => null,
+    textContent: '',
+    ...overrides,
+  } as unknown as HTMLElement
+}
+
+describe('queryScrollable', () => {
+  it('returns the first scrollable element matching the pack scroll-container primary', () => {
+    const scroller = elWith({ scrollHeight: 800, clientHeight: 400 })
+    const root = fakeRoot({ '.yDSiEe.uGCjIb.zcLWac': [scroller] })
+    expect(queryScrollable(SELECTOR_DEFS.scrollContainer, root)).toBe(scroller)
+  })
+
+  it('skips a non-scrollable primary and uses a scrollable pack fallback', () => {
+    const nonScroller = elWith({ scrollHeight: 400, clientHeight: 400 })
+    const gridScroller = elWith({ scrollHeight: 1200, clientHeight: 600 })
+    const root = fakeRoot({
+      '.yDSiEe.uGCjIb.zcLWac': [nonScroller],
+      '[role="grid"]': [gridScroller],
+    })
+    expect(queryScrollable(SELECTOR_DEFS.scrollContainer, root)).toBe(gridScroller)
+  })
+
+  it('returns null when no pack candidate scrolls (unknown DOM fails closed)', () => {
+    expect(queryScrollable(SELECTOR_DEFS.scrollContainer, fakeRoot({}))).toBeNull()
+  })
+})
+
+describe('queryAllUnion', () => {
+  it('unions pack primary and fallback matches without duplicates', () => {
+    const roleDialog = elWith()
+    const alertDialog = elWith()
+    const ariaModal = elWith()
+    const root = fakeRoot({
+      '[role="dialog"]': [roleDialog],
+      '[role="alertdialog"]': [alertDialog, roleDialog],
+      '[aria-modal="true"]': [ariaModal],
+    })
+    expect(queryAllUnion<HTMLElement>(SELECTOR_DEFS.dialog, root)).toEqual([
+      roleDialog,
+      alertDialog,
+      ariaModal,
+    ])
+  })
+
+  it('returns an empty list when nothing matches (unknown DOM fails closed)', () => {
+    expect(queryAllUnion(SELECTOR_DEFS.dialog, fakeRoot({}))).toEqual([])
+  })
+})
+
+describe('findConfirmDialog', () => {
+  const g = globalThis as unknown as { document?: unknown }
+
+  afterEach(() => {
+    delete g.document
+  })
+
+  it('finds a dialog matched through the versioned pack primary', () => {
+    const dialog = elWith()
+    g.document = fakeRoot({ '[role="dialog"]': [dialog] })
+    expect(findConfirmDialog()).toBe(dialog)
+  })
+
+  it('finds a dialog matched through a pack fallback selector', () => {
+    const dialog = elWith()
+    g.document = fakeRoot({ '[aria-modal="true"]': [dialog] })
+    expect(findConfirmDialog()).toBe(dialog)
+  })
+
+  it('returns null when no pack dialog selector matches (unknown DOM fails closed)', () => {
+    g.document = fakeRoot({})
+    expect(findConfirmDialog()).toBeNull()
   })
 })


### PR DESCRIPTION
## GPDT-OBSERVE — pack-owned scroll container and dialog selectors

### Identity
- **ID**: GPDT-OBSERVE
- **Fate**: live
- **Identity text**: Interpret the current Google Photos DOM fail closed
- **Dependencies**: GPDT-ENTER (landed via #8)
- **Destination revision**: `de4cd4aec2ba4ea4c845366aa462ac90e4a884b7` (GPDT-ENTER landed via #8)

### Write/effect set (source only)
Versioned selector pack for media tiles, selection state, scroll container,
dialogs, and destructive candidates; action candidates require a pack-owned
exact action selector or positive accessible text; unknown DOM returns no
candidate; bounded diagnostics retain pack and observed match evidence.

Files (this PR):
- `src/selector-packs/pack-v1.json` — pack v3; adds `scrollContainer` and
  `dialog` selector defs alongside existing media-tile, selection-state, and
  destructive-candidate data.
- `src/core/selector-pack.ts` — `SelectorPack.selectors` contract now includes
  `scrollContainer` and `dialog`.
- `src/core/selectors.ts` — `findConfirmDialog` and `isInsideDialog` resolve the
  pack-owned `dialog` def (union of primary + fallbacks) instead of hardcoded
  strings; new `queryAllUnion` and `queryScrollable` finders record observed
  match evidence (primary/fallback/none) into the bounded diagnostics blob.
- `src/core/browser-dom.ts` — `findScrollTarget` resolves the pack-owned
  `scrollContainer` def; unknown DOM returns no candidate (browser-native
  document scroller remains a last-resort fallback).
- `scripts/verify.ts` — artifact gate now asserts pack v3 and that the pack
  identifies the scroll container and dialogs.
- `tests/selector-pack.test.ts`, `tests/selectors.test.ts` — accompaniment:
  pack v3 shape, `queryScrollable`/`queryAllUnion`/`findConfirmDialog`
  fail-closed behavior.

Out of scope (not taken by this leaf): GPDT-BATCH / GPDT-EMPTY-VERIFY live
destructive paths; no Platform/Hands/JIT; no live Google Photos proof. The
GPDT-EVIDENCE live gate remains residual.

### Oracle / evidence layer
- Oracle: destination `docs/capabilities.md` GPDT-OBSERVE Done-when.
- Evidence layer: **source/candidate**. No claim of live Google Photos proof.
- Local proof: `bun run typecheck`, `bun run lint`, `bun run test` (17 files,
  198 tests), `bun run build`, `bun run listing:check`, `bun run verify`, and
  `bun run zip` all pass on this SHA.

### Recovery path
Revert/repair is a single-commit rollback of this PR; the pack data file is
the drift-fix surface for any future Google Photos DOM change (bump version,
adjust selectors — no code surgery).
