### PR TITLE
feat(core): dry-run treats deduplicated label counts as browser observations (GPDT-PREVIEW)

### DIFF
--- a/src/core/delete-engine.ts
+++ b/src/core/delete-engine.ts
@@ -17,12 +17,18 @@ export class StopRequested extends Error {
 }
 
 export interface Progress {
+  /** Photos actually moved to Trash. Always 0 for a dry-run scan — a preview never mutates. */
   deleted: number
   selected: number
   status: RunStatus
   startedAt: number
   error?: string
-  /** Gallery total; set when known (dry-run scan). */
+  /**
+   * Distinct matching labels observed by a dry-run scan. This is a
+   * deduplicated *browser observation* (Set of aria-labels seen in the
+   * DOM), never a deletion count, and it is set only by the dry-run
+   * path. `deleted` stays 0 while `total` carries the observation.
+   */
   total?: number
 }
 
@@ -49,7 +55,10 @@ export interface EngineOptions {
  *   4. Detect end-of-gallery: when neither selection nor scroll moved
  *      anything N times in a row (`endOfListAttempts`), break the loop.
  *
- * Dry-run takes a separate path (runDryRunScan) — see that method.
+ * Dry-run takes a separate path (runDryRunScan) — see that method. It
+ * scrolls and counts observed matching labels, reports the deduplicated
+ * count as progress.total (a browser observation), and never reports it
+ * as progress.deleted — a preview mutates nothing.
  *
  * Stop is abort-aware: every wait yields to `stop()`, and a stopped run
  * resolves with status 'idle', NEVER 'error'. The `finally` block flushes
@@ -76,8 +85,9 @@ export class DeleteEngine {
   readonly log = new DeletionLog()
 
   /**
-   * Labels harvested by the last dry-run scan (for Pro CSV export).
-   * Empty for real-delete runs and before any dry-run completes.
+   * Labels observed by the last dry-run scan (deduplicated browser
+   * observations, for Pro CSV export). Empty for real-delete runs and
+   * before any dry-run completes.
    */
   getDryRunLabels(): readonly string[] {
     return this.dryRunLabelsArr
@@ -294,6 +304,11 @@ export class DeleteEngine {
    * each visible photo's stable identifier (aria-label of its labelled
    * ancestor) into a Set. Final tally = Set size. Never clicks anything.
    *
+   * The tally is a browser observation: progress.deleted stays 0 for the
+   * whole scan and the deduplicated Set size is surfaced as
+   * progress.total. Stop resolves to 'idle' and the scan never calls a
+   * destructive path, so a stopped dry-run can never become a delete.
+   *
    * Two coverage measures keep us from missing photos that briefly
    * appear in the DOM during a scroll and disappear before we look:
    *   1. We harvest IDs continuously while waiting for each scroll
@@ -326,8 +341,10 @@ export class DeleteEngine {
     }
 
     // Initial harvest at the top before we touch the scroll target.
+    // The deduplicated Set size is a browser observation → progress.total.
+    // progress.deleted stays 0: nothing has been (or will be) deleted.
     this.harvestVisibleIds(seen, (warned) => { missingIdWarned = warned })
-    this.progress.deleted = seen.size
+    this.progress.total = seen.size
     this.emitProgress()
 
     try {
@@ -343,7 +360,7 @@ export class DeleteEngine {
         const gained = seen.size - before
         const heightGrew = target ? target.scrollHeight > heightBefore : false
 
-        this.progress.deleted = seen.size
+        this.progress.total = seen.size
         if (gained > 0) this.log.record(gained)
         this.emitProgress()
 
@@ -402,7 +419,8 @@ export class DeleteEngine {
       if (this.progress.status !== 'error') {
         this.progress.status = this.stopped ? 'idle' : 'done'
       }
-      this.progress.deleted = seen.size
+      // Report the observation, never a deletion count.
+      this.progress.deleted = 0
       this.progress.total = seen.size
       this.dryRunLabelsArr = [...seen]
       this.emitProgress()
@@ -442,7 +460,7 @@ export class DeleteEngine {
     }
     if (seen.size > beforeSize) {
       console.log(`${LOG} [dry-run] final settle picked up ${seen.size - beforeSize} more`)
-      this.progress.deleted = seen.size
+      this.progress.total = seen.size
       this.emitProgress()
     }
   }

--- a/tests/delete-engine.test.ts
+++ b/tests/delete-engine.test.ts
@@ -380,7 +380,7 @@ describe('DeleteEngine — type filter', () => {
 })
 
 describe('DeleteEngine — dry-run scan', () => {
-  it('counts unique labels, never clicks, and reports a total', async () => {
+  it('counts unique labels as browser observations, never clicks, reports total', async () => {
     const dom = new FakeDom()
     dom.setTiles(['Photo - a', 'Photo - b', 'Photo - c'])
     const { engine, onProgress } = makeEngine(dom, { maxCount: 500, dryRun: true })
@@ -388,15 +388,24 @@ describe('DeleteEngine — dry-run scan', () => {
     const result = await engine.run()
 
     expect(result.status).toBe('done')
+    // The deduplicated label count is an observation (total), not a deletion.
     expect(result.total).toBe(3)
-    expect(result.deleted).toBe(3)
+    expect(result.deleted).toBe(0)
     expect(dom.clicks.filter((c) => c === 'confirm')).toHaveLength(0)
     expect(dom.clicks.some((c) => c.startsWith('tile:'))).toBe(false)
     expect(engine.getDryRunLabels()).toHaveLength(3)
     expect(statusesOf(onProgress)).toContain('done')
+    // Every live progress emission during the scan keeps deleted at 0 and
+    // carries the observed count as total — never the reverse.
+    for (const [snapshot] of onProgress.mock.calls) {
+      expect(snapshot.deleted).toBe(0)
+      if (snapshot.total !== undefined) {
+        expect(snapshot.total).toBeGreaterThanOrEqual(snapshot.deleted)
+      }
+    }
   })
 
-  it('dry-run with a type filter counts only matching labels', async () => {
+  it('dry-run with a type filter counts only matching labels as observations', async () => {
     const dom = new FakeDom()
     dom.setTiles(['Screenshot - shot', 'Video - clip', 'Photo - pic'])
     const { engine } = makeEngine(dom, { maxCount: 500, dryRun: true }, { kind: 'type', type: 'screenshot' })
@@ -404,6 +413,7 @@ describe('DeleteEngine — dry-run scan', () => {
     const result = await engine.run()
     expect(result.status).toBe('done')
     expect(result.total).toBe(1)
+    expect(result.deleted).toBe(0)
   })
 
   it('deduplicates identical labels (burst-mode undercount is expected)', async () => {
@@ -413,6 +423,30 @@ describe('DeleteEngine — dry-run scan', () => {
 
     const result = await engine.run()
     expect(result.total).toBe(1)
+    expect(result.deleted).toBe(0)
+  })
+
+  it('stopping a dry-run resolves to idle, never deletes, and keeps the observation', async () => {
+    const dom = new FakeDom()
+    dom.manualSleep = true
+    dom.setTiles(['Photo - a', 'Photo - b', 'Photo - c'])
+    const { engine } = makeEngine(dom, { maxCount: 500, dryRun: true })
+
+    const runPromise = engine.run()
+    await new Promise((r) => setTimeout(r, 5))
+    engine.stop()
+    dom.releaseSleep()
+
+    const result = await runPromise
+
+    // A stopped dry-run is idle (never error), mutated nothing, and its
+    // observed count is reported as total — it cannot become a delete.
+    expect(result.status).toBe('idle')
+    expect(result.error).toBeUndefined()
+    expect(result.deleted).toBe(0)
+    expect(dom.clicks.filter((c) => c === 'confirm')).toHaveLength(0)
+    expect(dom.clicks.some((c) => c.startsWith('tile:'))).toBe(false)
+    expect(engine.getDryRunLabels().length).toBeLessThanOrEqual(3)
   })
 })
 


### PR DESCRIPTION
## GPDT-PREVIEW — dry-run reports observed label counts as browser observations

- **Identity / fate:** GPDT-PREVIEW (`Preview the current-view scope without mutation`) — **live**
- **Depends on:** GPDT-OBSERVE (landed on master @ `ef147eb4d5b392be6df872c5b3c31396656f88df`)
- **Destination revision:** `docs/vision.md` @ `5565646b85ae0e755d826271ec6c0673706103be` (on top of master @ `ef147eb4d5b392be6df872c5b3c31396656f88df`)
- **Write/effect set:** GPDT-PREVIEW source only — `src/core/delete-engine.ts` (contract) + `tests/delete-engine.test.ts` (accompaniment). No edits to `page-runner.ts` / `content.ts` (GPDT-CONSENT collision), no destructive click path, no live deletions.
- **Oracle / evidence layer:** source/candidate.

### Done-when → evidence

1. **Dry-run path scrolls and counts observed matching labels without invoking any click**
   - `runDryRunScan()` scrolls via `scrollTo`/`scrollBy` and counts matching labels into a `Set`; the dry-run path never calls `dom.click` and `run()` returns the scan before the destructive loop. Tests assert zero `confirm` and zero `tile:` clicks.
2. **Clearly treats deduplicated label counts as browser observations**
   - `progress.deleted` now stays `0` for the whole dry-run scan (a preview mutates nothing); the deduplicated `Set` size is surfaced as `progress.total`, documented as a *browser observation* (Set of aria-labels seen in the DOM), never a deletion count. Live emissions carry `total` as the scan grows. `getDryRunLabels()` is documented as observed labels.
   - Tests assert `deleted === 0`, `total === N`, and every live emission keeps `deleted` at 0 while carrying `total`.
3. **Can be stopped without becoming a destructive run**
   - Dry-run loop yields on `stop()`/pause and resolves to `idle`; no destructive call exists in the scan path. New test: a stopped dry-run resolves to `idle`, reports `deleted === 0`, and clicks nothing.

### Local proof

- `bun run typecheck` — pass
- `bun run test` — 199/199 pass (17 delete-engine incl. new stop-safety test)
- `bun run lint` — pass
- `bun run build` + `bun run verify` — pass (pack v3, all artifacts consistent)

### Recovery path

If a review worker rejects this SHA: revert `src/core/delete-engine.ts` dry-run `deleted`/`total` assignments to `master` behavior or re-apply the contract with the reviewer's correction; the destructive path is untouched, so no deletion behavior is affected by this candidate.
