### PR TITLE
feat: admit explicit destructive intent (GPDT-CONSENT)

### DIFF
--- a/src/core/page-runner.ts
+++ b/src/core/page-runner.ts
@@ -38,12 +38,20 @@ export interface DryRunSummary {
 }
 
 const CONSENT_KEY = 'gpdt_consent_v3'
+const EMPTY_TRASH_ACK_KEY = 'gpdt_emptyTrashAck_v3'
 const LICENSE_KEY = 'gpdt_pro_token_v3'
 
 export class ConsentRequiredError extends Error {
   constructor() {
     super('consent required before a destructive run')
     this.name = 'ConsentRequiredError'
+  }
+}
+
+export class PermanentActionRequiredError extends Error {
+  constructor() {
+    super('permanent empty-trash acknowledgement required before an empty-trash run')
+    this.name = 'PermanentActionRequiredError'
   }
 }
 
@@ -106,6 +114,29 @@ export class PageRunner {
     }
   }
 
+  /**
+   * Permanent empty-trash acknowledgement — the second, explicit
+   * acknowledgement recorded when the user confirms the permanent-action
+   * warning while the "Empty trash afterwards" option is selected.
+   * Required (alongside the general consent) for any non-dry run that
+   * chains into the permanent empty-trash flow.
+   */
+  emptyTrashAcknowledged(): boolean {
+    try {
+      return window.localStorage.getItem(EMPTY_TRASH_ACK_KEY) === '1'
+    } catch {
+      return false
+    }
+  }
+
+  acknowledgeEmptyTrash(): void {
+    try {
+      window.localStorage.setItem(EMPTY_TRASH_ACK_KEY, '1')
+    } catch {
+      /* storage unavailable — acknowledgement re-asked next time */
+    }
+  }
+
   // ─── Pro license ──────────────────────────────────────────────
 
   getLicenseToken(): string | null {
@@ -146,7 +177,10 @@ export class PageRunner {
 
   async start(opts: PanelRunOptions): Promise<void> {
     if (this.running) return
-    if (!opts.dryRun && !this.consentAcknowledged()) throw new ConsentRequiredError()
+    if (!opts.dryRun) {
+      if (!this.consentAcknowledged()) throw new ConsentRequiredError()
+      if (opts.emptyTrashAfter && !this.emptyTrashAcknowledged()) throw new PermanentActionRequiredError()
+    }
     this.running = true
     this.summary = null
     this.progress = null

--- a/src/extension/content.ts
+++ b/src/extension/content.ts
@@ -35,6 +35,12 @@ const STORAGE_KEYS = {
   emptyTrashAfter: 'gpdt_emptyAfter',
   /** Consent acknowledgment for destructive runs (v3). */
   consent: 'gpdt_consent_v3',
+  /**
+   * Permanent empty-trash acknowledgement (v3). Required — in addition
+   * to the general consent — before a real run that selects the
+   * permanent "Empty trash afterwards" option is admitted.
+   */
+  emptyTrashAck: 'gpdt_emptyTrashAck_v3',
 } as const
 
 // ─── Engine lifecycle ───────────────────────────────────────────
@@ -73,6 +79,21 @@ const start = async (opts: StartOptions): Promise<{ ok: boolean; error?: string 
       } catch (err) {
         console.warn(`${LOG} consent read failed:`, err)
         return { ok: false, error: 'Could not read consent state.' }
+      }
+
+      if (emptyTrashAfter) {
+        try {
+          const data = await storageGet([STORAGE_KEYS.emptyTrashAck])
+          if (!data[STORAGE_KEYS.emptyTrashAck]) {
+            return {
+              ok: false,
+              error: 'Permanent empty-trash consent required — confirm the permanent-action warning in the popup first.',
+            }
+          }
+        } catch (err) {
+          console.warn(`${LOG} empty-trash consent read failed:`, err)
+          return { ok: false, error: 'Could not read permanent empty-trash consent state.' }
+        }
       }
     }
 

--- a/src/extension/popup/popup.html
+++ b/src/extension/popup/popup.html
@@ -143,6 +143,10 @@
           </span>
         </label>
       </div>
+      <!-- GPDT-CONSENT: the permanent-action warning is presented the
+           moment the empty-trash option is selected, before any run is
+           admitted, even when the general consent is already stored. -->
+      <p class="consent-danger hidden" id="empty-trash-warning" role="alert" data-i18n="consent.permanentNote">"Empty trash afterwards" is PERMANENT — no recovery.</p>
 
       <div class="field">
         <label class="field-label" for="filter">

--- a/src/extension/popup/popup.ts
+++ b/src/extension/popup/popup.ts
@@ -31,6 +31,7 @@ const LOG = '[gpdt:popup]'
 const maxCountInput   = document.getElementById('max-count')      as HTMLInputElement
 const dryRunInput     = document.getElementById('dry-run')        as HTMLInputElement
 const emptyTrashInput = document.getElementById('empty-trash')    as HTMLInputElement
+const emptyTrashWarning = document.getElementById('empty-trash-warning') as HTMLElement
 const filterSelect    = document.getElementById('filter')         as HTMLSelectElement
 const licenseInput    = document.getElementById('license-token')  as HTMLInputElement
 const licenseBtn      = document.getElementById('license-btn')    as HTMLButtonElement
@@ -96,6 +97,7 @@ let currentView: PhotosView | null = null
 let surfaceReady = false
 
 const CONSENT_KEY = 'gpdt_consent_v3'
+const EMPTY_TRASH_ACK_KEY = 'gpdt_emptyTrashAck_v3'
 const PRO_TOKEN_KEY = 'proToken'
 
 // ─── Locale init ────────────────────────────────────────────────
@@ -267,7 +269,10 @@ dryRunInput.addEventListener('change', () => {
   saveSettings()
   refreshDryRunDependentFields()
 })
-emptyTrashInput.addEventListener('change', saveSettings)
+emptyTrashInput.addEventListener('change', () => {
+  saveSettings()
+  refreshEmptyTrashWarning()
+})
 filterSelect.addEventListener('change', saveSettings)
 
 // ─── Pro license ────────────────────────────────────────────────
@@ -445,6 +450,15 @@ const stopElapsedTimer = (): void => {
 
 // ─── Consent gate ───────────────────────────────────────────────
 
+/**
+ * The permanent-action warning for "Empty trash afterwards" is shown
+ * the moment the option is selected, before any run is admitted —
+ * independently of whether the general consent is already stored.
+ */
+const refreshEmptyTrashWarning = (): void => {
+  emptyTrashWarning.classList.toggle('hidden', !emptyTrashInput.checked)
+}
+
 async function consentAcknowledged(): Promise<boolean> {
   try {
     const data = await storageGet([CONSENT_KEY])
@@ -462,15 +476,38 @@ async function acknowledgeConsent(): Promise<void> {
   }
 }
 
+/** Permanent empty-trash acknowledgement (parallel to the general consent). */
+async function emptyTrashAcknowledged(): Promise<boolean> {
+  try {
+    const data = await storageGet([EMPTY_TRASH_ACK_KEY])
+    return data[EMPTY_TRASH_ACK_KEY] === true
+  } catch {
+    return false
+  }
+}
+
+async function acknowledgeEmptyTrash(): Promise<void> {
+  try {
+    await storageSet({ [EMPTY_TRASH_ACK_KEY]: true })
+  } catch (err) {
+    console.warn(`${LOG} empty-trash consent persist failed:`, err)
+  }
+}
+
 let pendingStart: { maxCount: number; dryRun: boolean; emptyTrashAfter: boolean; filter: PhotoFilter } | null = null
 
-consentConfirm.addEventListener('click', () => {
+consentConfirm.addEventListener('click', async () => {
   if (!consentCheck.checked) return
-  void acknowledgeConsent()
+  // Await the storage writes: the content-script gate reads these keys
+  // again when it admits the run, so starting before the writes land
+  // would spuriously refuse the run.
+  await acknowledgeConsent()
+  if (pendingStart?.emptyTrashAfter) await acknowledgeEmptyTrash()
   consentBox.classList.add('hidden')
-  if (pendingStart) {
-    void doStart(pendingStart)
-    pendingStart = null
+  const start = pendingStart
+  pendingStart = null
+  if (start) {
+    void doStart(start)
   }
 })
 
@@ -499,7 +536,7 @@ startBtn.addEventListener('click', async () => {
     saveSettings()
     hideError()
 
-    if (!opts.dryRun && !(await consentAcknowledged())) {
+    if (!opts.dryRun && (!(await consentAcknowledged()) || (opts.emptyTrashAfter && !(await emptyTrashAcknowledged())))) {
       pendingStart = opts
       consentPermanent.classList.toggle('hidden', !opts.emptyTrashAfter)
       consentCheck.checked = false
@@ -737,6 +774,7 @@ void (async () => {
     filterSelect.value = data.filter
   }
   refreshDryRunDependentFields()
+  refreshEmptyTrashWarning()
   void refreshProState()
   void refreshSurfaceAdmission()
   void queryInitialStatus()

--- a/src/ui/panel/panel.ts
+++ b/src/ui/panel/panel.ts
@@ -109,6 +109,7 @@ export function mountPanel(container: HTMLElement, runner: PageRunner): void {
       <label for="gpdt-empty" title="Permanent — no recovery">Empty trash afterwards</label>
       <input type="checkbox" id="gpdt-empty" style="accent-color:#ef4444" />
     </div>
+    <div id="gpdt-empty-warning" class="gpdt-danger" style="display:none">"Empty trash afterwards" is PERMANENT with no recovery.</div>
     <div class="gpdt-row">
       <label for="gpdt-filter">Filter (Pro)</label>
       <select id="gpdt-filter" style="width:150px" disabled>
@@ -165,6 +166,7 @@ export function mountPanel(container: HTMLElement, runner: PageRunner): void {
   const maxInput = $<HTMLInputElement>('gpdt-max')
   const dryRunInput = $<HTMLInputElement>('gpdt-dryrun')
   const emptyInput = $<HTMLInputElement>('gpdt-empty')
+  const emptyWarning = $<HTMLElement>('gpdt-empty-warning')
   const filterSelect = $<HTMLSelectElement>('gpdt-filter')
   const licenseInput = $<HTMLInputElement>('gpdt-license')
   const licenseStatus = $<HTMLElement>('gpdt-license-status')
@@ -219,6 +221,13 @@ export function mountPanel(container: HTMLElement, runner: PageRunner): void {
 
   // ─── Consent gate ─────────────────────────────────────────────
 
+  // GPDT-CONSENT: the permanent-action warning is presented the moment
+  // the option is selected, before any run is admitted — independently
+  // of whether the general consent is already stored.
+  emptyInput.addEventListener('change', () => {
+    emptyWarning.style.display = emptyInput.checked ? 'block' : 'none'
+  })
+
   const readOptions = (): PanelRunOptions => {
     const parsed = parseInt(maxInput.value, 10)
     const kind = filterSelect.value
@@ -236,7 +245,7 @@ export function mountPanel(container: HTMLElement, runner: PageRunner): void {
 
   startBtn.addEventListener('click', () => {
     const opts = readOptions()
-    if (!opts.dryRun && !runner.consentAcknowledged()) {
+    if (!opts.dryRun && (!runner.consentAcknowledged() || (opts.emptyTrashAfter && !runner.emptyTrashAcknowledged()))) {
       pendingStart = opts
       consentPermanent.style.display = opts.emptyTrashAfter ? 'block' : 'none'
       consentCheck.checked = false
@@ -253,6 +262,7 @@ export function mountPanel(container: HTMLElement, runner: PageRunner): void {
   $<HTMLButtonElement>('gpdt-consent-confirm').addEventListener('click', () => {
     if (!consentCheck.checked) return
     runner.acknowledgeConsent()
+    if (pendingStart?.emptyTrashAfter) runner.acknowledgeEmptyTrash()
     consentBox.style.display = 'none'
     if (pendingStart) {
       void runner.start(pendingStart).catch((err: unknown) => {

--- a/tests/ui-wiring.test.ts
+++ b/tests/ui-wiring.test.ts
@@ -106,3 +106,65 @@ describe('GPDT-ENTER surface contract', () => {
   })
 })
 
+describe('permanent empty-trash acknowledgement contract', () => {
+  it('popup, content, and page-runner use the same empty-trash acknowledgement key', () => {
+    const popupTs = read('src/extension/popup/popup.ts')
+    const contentTs = read('src/extension/content.ts')
+    const runnerTs = read('src/core/page-runner.ts')
+    const popupKey = popupTs.match(/EMPTY_TRASH_ACK_KEY = '([^']+)'/)?.[1]
+    const contentKey = contentTs.match(/emptyTrashAck: '([^']+)'/)?.[1]
+    const runnerKey = runnerTs.match(/EMPTY_TRASH_ACK_KEY = '([^']+)'/)?.[1]
+    expect(popupKey).toBeTruthy()
+    expect(contentKey).toBeTruthy()
+    expect(runnerKey).toBeTruthy()
+    expect(new Set([popupKey, contentKey, runnerKey]).size).toBe(1)
+  })
+
+  it('content refuses a permanent empty-trash run without the acknowledgement', () => {
+    const contentTs = read('src/extension/content.ts')
+    // The ack gate lives on the non-dry path and is read through the
+    // same storage wrapper as the general consent.
+    expect(contentTs).toContain('STORAGE_KEYS.emptyTrashAck')
+    expect(contentTs).toContain('if (emptyTrashAfter)')
+    expect(contentTs).toContain("error: 'Permanent empty-trash consent required")
+    expect(contentTs).toContain("error: 'Could not read permanent empty-trash consent state.'")
+  })
+
+  it('page-runner refuses a permanent empty-trash run without the acknowledgement', () => {
+    const runnerTs = read('src/core/page-runner.ts')
+    expect(runnerTs).toContain('opts.emptyTrashAfter && !this.emptyTrashAcknowledged()')
+    expect(runnerTs).toContain('export class PermanentActionRequiredError')
+    expect(runnerTs).toContain('acknowledgeEmptyTrash(): void')
+  })
+})
+
+describe('permanent empty-trash warning is visible on selection', () => {
+  it('popup shows the permanent-action warning the moment Empty trash is selected', () => {
+    const popupTs = read('src/extension/popup/popup.ts')
+    const popupHtml = read('src/extension/popup/popup.html')
+    expect(popupHtml).toMatch(/id="empty-trash-warning"/)
+    expect(popupHtml).toMatch(/data-i18n="consent\.permanentNote"/)
+    expect(popupTs).toContain("const emptyTrashWarning = document.getElementById('empty-trash-warning')")
+    expect(popupTs).toContain("emptyTrashInput.addEventListener('change'")
+    expect(popupTs).toContain("emptyTrashWarning.classList.toggle('hidden', !emptyTrashInput.checked)")
+  })
+
+  it('panel shows the permanent-action warning the moment Empty trash is selected', () => {
+    const panelTs = read('src/ui/panel/panel.ts')
+    expect(panelTs).toMatch(/id="gpdt-empty-warning"/)
+    expect(panelTs).toContain("const emptyWarning = $<HTMLElement>('gpdt-empty-warning')")
+    expect(panelTs).toContain("emptyInput.addEventListener('change'")
+    expect(panelTs).toContain("emptyWarning.style.display = emptyInput.checked ? 'block' : 'none'")
+  })
+
+  it('popup and panel gate a permanent empty-trash run on the acknowledgement, not only on consent', () => {
+    const popupTs = read('src/extension/popup/popup.ts')
+    const panelTs = read('src/ui/panel/panel.ts')
+    expect(popupTs).toContain('opts.emptyTrashAfter && !(await emptyTrashAcknowledged())')
+    expect(panelTs).toContain('opts.emptyTrashAfter && !runner.emptyTrashAcknowledged()')
+    // Both surfaces record the acknowledgement at the same confirm
+    // moment where the permanent warning is visible.
+    expect(popupTs).toContain("if (pendingStart?.emptyTrashAfter) await acknowledgeEmptyTrash()")
+    expect(panelTs).toContain("if (pendingStart?.emptyTrashAfter) runner.acknowledgeEmptyTrash()")
+  })
+})


### PR DESCRIPTION
## Identity

- **identity:** `GPDT-CONSENT` — Admit explicit destructive intent
- **fate:** `live` (as declared)
- **destination revision:** `de4cd4aec2ba4ea4c845366aa462ac90e4a884b7` (`docs/vision.md` + `docs/capabilities.md` — GPDT-ENTER landed; GPDT-OBSERVE #9 not stacked, its files untouched)
- **candidate_sha:** `0e142567cea337bef4be5430bc2afd678bbb7a61`

## Write-set

One identity's source files for `GPDT-CONSENT`:

- `src/core/page-runner.ts` — refuse a non-dry run that selects the permanent empty-trash option when the permanent-action acknowledgement is absent or unreadable (parallel to the general consent gate); add `emptyTrashAcknowledged()` / `acknowledgeEmptyTrash()` and `PermanentActionRequiredError`.
- `src/extension/content.ts` — the extension enforcement layer now refuses a non-dry run with `emptyTrashAfter` when the shared `gpdt_emptyTrashAck_v3` acknowledgement is absent or unreadable, in addition to the existing consent gate.
- `src/extension/popup/popup.html` + `src/extension/popup/popup.ts` — the permanent-action warning is presented the moment the "Empty trash" option is selected (before any admission, even when the general consent is already stored); the acknowledgement is recorded at the same confirm moment where the warning is visible, and the storage write is awaited before the run is dispatched.
- `src/ui/panel/panel.ts` — same on-selection warning + acknowledgement gate for the userscript/standalone surface.
- `tests/ui-wiring.test.ts` — contract tests: shared acknowledgement key identity across popup/content/runner, on-selection warning wiring, and the fail-closed refusal at both enforcement layers.

Does not edit `docs/vision.md` or `docs/capabilities.md`. Does not touch `src/selector-packs/**`, `src/core/selector-pack.ts`, `src/core/selectors.ts`, or `src/core/browser-dom.ts`. No live deletions; no store/release effect.

## Done-when (oracle, named at source)

1. Every non-dry run is refused when the shared local consent acknowledgement (`gpdt_consent_v3`) is absent or unreadable — already enforced by `content.ts` and `page-runner.ts`; preserved and verified.
2. Choosing the permanent empty-trash option makes that consequence visible before admission: selecting the option presents the permanent-action warning immediately in both surfaces (previously the warning only appeared inside the consent box when the general consent was absent — a stored consent admitted an empty-trash run with no warning presented). A real run with `emptyTrashAfter` is additionally refused unless the permanent-action acknowledgement is recorded, so the consequence cannot be skipped at the enforcement layer.

## Evidence layer

Source / local tests. Not CI, not landed, not live-browser, not store.

Run locally at `candidate_sha` (`0e142567cea337bef4be5430bc2afd678bbb7a61`, working tree clean):

- `bun run typecheck` — pass
- `bun run lint` — pass
- `bun run test` — 204 passed (17 files)
- `bun run build` — pass (Chrome + Firefox extension, standalone, userscript)
- `bun run verify` — pass (all artifacts consistent)

No live Google Photos session; no destructive action was performed.

## Recovery

Revert this PR / drop this branch. No data migration, no live writer, no store publish. Existing stored consents remain valid; an existing consent without the new empty-trash acknowledgement gets one extra confirm (with the permanent warning visible) before a permanent empty-trash run is admitted.

## Next action

A different session reviews this SHA independently. Do not merge from this Worker. The forge waits.

- base: `master@ef147eb4d5b392be6df872c5b3c31396656f88df`
