### PR TITLE
feat(core): fail closed on a non-positive batch limit (GPDT-BATCH)

### DIFF
--- a/src/core/delete-engine.ts
+++ b/src/core/delete-engine.ts
@@ -152,6 +152,36 @@ export class DeleteEngine {
   async run(): Promise<Progress> {
     this.stopped = false
     this.paused = false
+
+    // Fail closed on a non-positive / non-finite batch limit. The batch
+    // contract is a *positive* limit (`config.ts`: "Must be > 0"), and a
+    // maxCount <= 0 would make every iteration satisfy
+    // `currentCount >= maxCount` and flush a no-op "batch" forever — a
+    // busy loop that never reaches scroll settle or end-of-list
+    // detection. An invalid limit is a configuration error, never a
+    // destructive run.
+    if (!Number.isFinite(this.config.maxCount) || this.config.maxCount < 1) {
+      this.progress = {
+        deleted: 0,
+        selected: 0,
+        status: 'error',
+        startedAt: Date.now(),
+        error:
+          `Invalid batch limit: maxCount must be a positive integer ` +
+          `(got ${String(this.config.maxCount)}).`,
+      }
+      this.emitProgress()
+      diagnostics.setEngine({
+        status: 'error',
+        error: this.progress.error,
+        deleted: 0,
+        selected: 0,
+        counterFallbackUsed: false,
+        flapRecoveries: 0,
+      })
+      return this.progress
+    }
+
     this.progress = {
       deleted: 0,
       selected: 0,

--- a/tests/delete-engine.test.ts
+++ b/tests/delete-engine.test.ts
@@ -450,6 +450,51 @@ describe('DeleteEngine — dry-run scan', () => {
   })
 })
 
+describe('DeleteEngine — positive batch limit (fail closed)', () => {
+  it.each([0, -1])('rejects maxCount=%i without selecting, clicking, or looping', async (maxCount) => {
+    const dom = new FakeDom()
+    dom.setTiles(['Photo - a', 'Photo - b', 'Photo - c'])
+    const { engine } = makeEngine(dom, { maxCount })
+
+    const result = await engine.run()
+
+    // The run resolves (no busy loop) with a config error, not a delete.
+    expect(result.status).toBe('error')
+    expect(result.error).toMatch(/maxCount must be a positive integer/)
+    expect(result.deleted).toBe(0)
+    expect(dom.clicks.filter((c) => c === 'delete')).toHaveLength(0)
+    expect(dom.clicks.filter((c) => c === 'confirm')).toHaveLength(0)
+    expect(dom.clicks.some((c) => c.startsWith('tile:'))).toBe(false)
+    expect(dom.tiles.every((t) => !t.checked)).toBe(true)
+  })
+
+  it('rejects a non-finite maxCount (NaN) as a config error', async () => {
+    const dom = new FakeDom()
+    dom.setTiles(['Photo - a'])
+    const { engine } = makeEngine(dom, { maxCount: NaN })
+
+    const result = await engine.run()
+
+    expect(result.status).toBe('error')
+    expect(result.error).toMatch(/maxCount must be a positive integer/)
+    expect(result.deleted).toBe(0)
+    expect(dom.clicks.filter((c) => c === 'confirm')).toHaveLength(0)
+  })
+
+  it('rejects a non-positive maxCount even before a dry-run scan', async () => {
+    const dom = new FakeDom()
+    dom.setTiles(['Photo - a', 'Photo - b'])
+    const { engine } = makeEngine(dom, { maxCount: 0, dryRun: true })
+
+    const result = await engine.run()
+
+    expect(result.status).toBe('error')
+    expect(result.error).toMatch(/maxCount must be a positive integer/)
+    expect(result.total).toBeUndefined()
+    expect(dom.clicks.some((c) => c.startsWith('tile:'))).toBe(false)
+  })
+})
+
 describe('DeleteEngine — error paths', () => {
   it('reports error when the toolbar delete button never appears', async () => {
     const dom = new FakeDom()


### PR DESCRIPTION
## Identity

- **identity:** `GPDT-BATCH` — Move matching media to Trash through bounded actions
- **fate:** `live` (as declared)
- **destination revision:** `14616457658a2e9ea7ce8ef1be902e9ae5e452d7` (`docs/vision.md` + `docs/capabilities.md` — GPDT-OBSERVE #9, GPDT-PREVIEW #10, GPDT-CONSENT #11 landed)

## Write/effect set (source only)

The engine selects only currently unchecked matching tiles up to the configured **positive** batch limit, bounds selection settling, scroll settling, end-of-list detection, and action/dialog waits, and clicks delete and confirm only after positive identification.

Files (this PR):

- `src/core/delete-engine.ts` — **production change**: `run()` now fails closed on a non-positive / non-finite `maxCount` (0, negative, or `NaN`) by resolving to `status: 'error'` with a config error and no clicks. Previously a `maxCount <= 0` made every iteration satisfy `currentCount >= maxCount`, flushing a no-op "batch" and `continue`ing forever — an unbounded busy loop that never reaches scroll settling or end-of-list detection. `config.ts` already declares `maxCount` "Must be > 0"; this enforces that contract at the engine layer.
- `tests/delete-engine.test.ts` — accompaniment: fail-closed contract tests for `maxCount` 0, -1, and `NaN`, asserting the run resolves to error without selecting, clicking delete/confirm, or deleting; also covers the dry-run path.

`src/core/config.ts` is unchanged (tests-only accompaniment permitted; no production change needed — its `> 0` contract is now enforced). Does not edit `docs/vision.md` or `docs/capabilities.md`. Does not take GPDT-EMPTY-VERIFY, GPDT-BATCH-VERIFY, GPDT-CONTROL, or any other leaf. No live deletions; no Platform/Hands/JIT.

## Done-when (oracle, named at source)

The engine selects only currently unchecked matching tiles up to the configured positive batch limit, bounds selection settling, scroll settling, end-of-list detection, and action/dialog waits, and clicks delete and confirm only after positive identification.

Audit result against `master@1461645`:

1. Selects only currently unchecked matching tiles — `selectVisibleCheckboxes` re-queries `uncheckedTiles()` per wave and filters via `shouldSelectTile` (photo-filter). Present.
2. Up to the configured **positive** batch limit — `remainingCapacity = maxCount - beforeCount` caps each batch, **but positivity was not enforced**: `maxCount <= 0` busy-looped forever (flush no-op `continue` past end-of-list). **Closed by this PR** via engine-level fail-closed validation.
3. Bounds selection settling — `selectionSettleMs` deadline in `selectVisibleCheckboxes`. Present.
4. Bounds scroll settling — `scrollSettleMs` in `tryScrollForMore`. Present.
5. End-of-list detection — `endOfListAttempts` consecutive no-progress iterations break the loop. Present.
6. Bounds action/dialog waits — `actionTimeout` on delete-button, dialog, confirm-button, and counter-reset waits in `deleteSelected`. Present.
7. Clicks delete and confirm only after positive identification — `waitFor` requires a non-null finder result; `findDeleteToolbarButton` / `findConfirmDialog` / `findConfirmButton` only return pack-owned exact selectors or positive keyword matches (fail closed). Present.

## Evidence layer

Source / local tests. Not CI, not landed, not live-browser, not store.

Run locally at candidate_sha (working tree clean):

- `bun run typecheck` — pass
- `bun run lint` — pass
- `bun run test` — 209 passed (17 files), including 4 new fail-closed tests
- `bun run build` — pass (Chrome + Firefox extension, standalone, userscript)
- `bun run verify` — pass (all artifacts consistent)

No live Google Photos session; no destructive action was performed.

## Recovery

Revert this PR / drop this branch. No data migration, no live writer, no store publish. The validation is a fail-closed guard: valid `maxCount > 0` runs are unaffected.

## Next action

A different session reviews this SHA independently. Do not merge from this Worker. The forge waits.

- base: `master@14616457658a2e9ea7ce8ef1be902e9ae5e452d7`