### PR TITLE
docs(capabilities): declare GOV-017 release boundary

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -79,3 +79,57 @@ flowchart TD
 The source and tests above are source/local evidence at the repository revision
 being inspected. The live-release protocol is an additional oracle, not evidence
 that this documentation change performed or passed a browser run.
+
+## Release boundary (GOV-017)
+
+Declared 2026-08-31 per company ADR-030 and governance audit GOV-017
+(`SylphxAI/owner` runbook `GOVERNANCE-AUDIT-2026-08-28.md`). Docs declaration
+of current truth only. This is a personal product under the `shtse8`
+organisation; its real boundary is store listings and browser scripts, not
+company delivery vocabulary.
+
+- **Public probe.** The published store listing is the cheapest falsifiable
+  customer-visible proof at this product's boundary: the Chrome Web Store
+  listing
+  `https://chromewebstore.google.com/detail/google-photos-delete-tool/jiahfbbfpacpolomdjlpdpiljllcdenb`
+  (plus the Edge Add-ons, Firefox AMO, and Greasy Fork listings) shows the
+  version a customer can actually install, and the `store-state` branch
+  (`state.json`) records what is live per store — advanced only after the
+  platform API confirms a publish. A green CI run or a GitHub Release asset
+  alone is not proof a store version is live, and per `RELEASE_GATE.md` only
+  a real disposable-account run against Google Photos proves the release.
+- **Owned manifest/migration writers.** Store pipelines are the release
+  writers: `release.yml` on `v*` tags builds, verifies artifacts, and creates
+  the GitHub Release (the source-of-truth assets); `store-retry.yml` (6-hour
+  cron) drives `store-publish.yml`, which uploads and publishes the package
+  to Chrome Web Store, Edge Add-ons, and Firefox AMO via each store's API;
+  `update-cws-listing.yml` pushes CWS listing metadata from
+  `storefront/listing.json`; `bootstrap-amo.yml` is a one-time AMO add-on
+  creation; Greasy Fork (userscript) is human-once, and the script updates
+  itself afterwards. Store dashboards are consumers of
+  `storefront/listing.json`, never a second source. Migration writer: none —
+  there is no database and no migration.
+- **Consumed receipts.** GitHub Actions run receipts and GitHub Release
+  assets; store-platform publish confirmations (CWS, Edge, AMO) recorded in
+  the `store-state` branch; store review queues (`ITEM_NOT_UPDATABLE` on
+  CWS, `InProgressSubmission` / `NoModulesUpdated` on Edge) are expected
+  retry states, not failure or success proof. At runtime the tool consumes
+  only the user's own signed-in Google Photos session in their browser. No
+  company Apps/Journal/Compute/Identity/Commerce receipts are consumed.
+- **Runtime effects.** Runs only inside the user's browser: the extension or
+  userscript activates on `photos.google.com`, performs versioned-pack-driven
+  DOM actions (observe, select, click delete/confirm, navigate to `/trash`),
+  and keeps consent and diagnostics in local browser storage. There is no
+  backend, server, database, or scheduled job of this product anywhere.
+- **Forbidden writes.** No destructive action without the local consent
+  acknowledgement (`GPDT-CONSENT`), no destructive control without a
+  pack-owned exact selector or positive accessible text — unknown DOM fails
+  closed (`GPDT-OBSERVE`), and `done` is never reported from a click alone
+  (`GPDT-EMPTY-VERIFY`). The release gate forbids publishing without the
+  `RELEASE_GATE.md` live-run evidence table. Store automation forbids
+  bypassing CAPTCHA or removing passwords/cookies/sessions from the user's
+  machine (STORE_AUTOMATION tiers), and content auto-posting from fresh
+  accounts is banned. Per the company register, this repo is a personal
+  product in the `shtse8` namespace: it must not be treated as a company
+  product or adopt company Apps/Journal/Compute/Identity/Commerce writers by
+  existing.


### PR DESCRIPTION
GOV-017 release-boundary declaration (company ADR-030 / [SylphxAI/owner governance audit GOV-017](https://github.com/SylphxAI/owner/blob/main/runbook/GOVERNANCE-AUDIT-2026-08-28.md)). Docs dest-lock only; declares current truth, no code or manifest change.

Five items, grounded in `.github/workflows/{release,store-retry,store-publish,publish-cws,update-cws-listing,bootstrap-amo}.yml`, `docs/RELEASE_GATE.md`, `docs/STORE_AUTOMATION.md`, `docs/CHROME_WEB_STORE_SETUP.md`, `storefront/README.md`, and existing rows in this file:

1. **Public probe** — the published store listing (CWS `jiahfbbfpacpolomdjlpdpiljllcdenb`, plus Edge/AMO/Greasy Fork) showing the installable version; the `store-state` branch records what is live per store, advanced only after platform API confirmation. CI green or a GitHub Release asset alone is not store-live proof.
2. **Owned manifest/migration writers** — store pipelines: `release.yml` (v* tags → build + GitHub Release assets, source of truth), `store-retry.yml` 6h cron → `store-publish.yml` (CWS/Edge/AMO upload→publish), `update-cws-listing.yml` (listing metadata from `storefront/listing.json`), `bootstrap-amo.yml` (one-time), Greasy Fork human-once. Migration writer: none (no database).
3. **Consumed receipts** — GitHub Actions runs + Release assets; store publish confirmations in `store-state`; review-queue states (`ITEM_NOT_UPDATABLE`, `InProgressSubmission`, `NoModulesUpdated`) as expected retries; at runtime, the user's own Google Photos session only. No company Apps/Journal/Compute/Identity/Commerce receipts.
4. **Runtime effects** — browser-only: extension/userscript on `photos.google.com`, versioned-pack DOM actions, local consent/diagnostics storage; no backend, server, DB, or schedule.
5. **Forbidden writes** — no destructive action without consent; no destructive control without pack-owned exact selector/positive accessible text (unknown DOM fails closed); `done` never from a click alone; no publish without `RELEASE_GATE.md` live-run evidence; no CAPTCHA bypass or credential/session exfiltration; dashboards never a second listing source; per the company register this stays a personal `shtse8`-namespace product and must not adopt company Apps/Journal/Compute/Identity/Commerce writers.

Unknowns: none material to this declaration — every writer named above is present in the repo; whether each store's current live version matches the latest tag is observable from the listings/`store-state` but was not read back in this docs-only change.