### PR TITLE
fix: source extension manifest version 3.0.1

### DIFF
--- a/scripts/verify.ts
+++ b/scripts/verify.ts
@@ -3,7 +3,7 @@
  *
  * Checks that the built artifacts are structurally correct and
  * self-consistent before they can be zipped / released:
- *   - manifest version == package version (both variants)
+ *   - source and built manifest version == package version (both variants)
  *   - Firefox manifest shape (background.scripts, no service_worker)
  *   - userscript metadata header matches the package version
  *   - IIFE self-containment (no import/import()/export statements)
@@ -36,6 +36,11 @@ function read(path: string): string {
 }
 
 console.log('verify: package version =', pkg.version)
+
+{
+  const m = JSON.parse(read('src/extension/manifest.json'))
+  check(m.version === pkg.version, `source chrome manifest version == ${pkg.version}`)
+}
 
 // ─── Chrome manifest ────────────────────────────────────────────
 {

--- a/src/extension/manifest.json
+++ b/src/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Google Photos Delete Tool",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Consent-gated bulk delete for Google Photos: batch select, dry-run, and empty-trash.",
   "permissions": [
     "storage"

--- a/tests/surface.test.ts
+++ b/tests/surface.test.ts
@@ -142,4 +142,12 @@ describe('GPDT-ENTER constants stay the single host writer', () => {
     expect(manifest.host_permissions).toEqual([SUPPORTED_MATCH_PATTERN])
     expect(manifest.content_scripts[0]?.matches).toEqual([SUPPORTED_MATCH_PATTERN])
   })
+
+  it('source manifest version equals package version', () => {
+    const manifest = JSON.parse(read('src/extension/manifest.json')) as {
+      version: string
+    }
+    const pkg = JSON.parse(read('package.json')) as { version: string }
+    expect(manifest.version).toBe(pkg.version)
+  })
 })


### PR DESCRIPTION
## Identity

- **identity:** packaging for `GPDT-ENTER` (extension source manifest version). No identity, fate, dependency, or oracle in `docs/capabilities.md` changes.
- **constraint identity:** `GPDT-CONSENT` — Admit explicit destructive intent — **fate remains `live`**. Consent-gated bulk delete remains consent-gated. This SHA does not edit consent, engine, empty-trash, or selector files.
- **fate:** `live` (as declared; dest docs untouched)
- **destination revision:** `b1805521c2036d6fe44c9577509937f78fcd1b86` (`docs/vision.md` + `docs/capabilities.md` — GOV-017 release boundary on `master`)
- **candidate_sha:** `8d4a4dbb1867223bd05ed601e50e46b01938718b`

## Write/effect set (source only)

`src/extension/manifest.json` version is **3.0.1** (from 3.0.0) so the source Chrome manifest matches `package.json` (`3.0.1`) and `storefront/listing.json` `appliesTo` (`3.0.1`).

Files (this PR):

- `src/extension/manifest.json` — production change: `"version": "3.0.0"` → `"3.0.1"`. Description, permissions, host_permissions, and content-script matches unchanged.
- `tests/surface.test.ts` — accompaniment: parse the source manifest JSON and assert `version` equals `package.json` `version` (fails if source and package drift again).
- `scripts/verify.ts` — accompaniment: the existing version-consistency gate only checked **built** manifests after `build.ts` overwrites `version` from `package.json`, which hid source drift. It now also parses `src/extension/manifest.json` and requires the same version.

Does not edit `docs/vision.md`, `docs/capabilities.md`, or `docs/RELEASE_GATE.md`. Does not touch `src/core/**`, consent UI, delete engine, store pipelines, or company dest (Keel / Cubloom GOV-008). No live deletions; no store/release effect.

Wider touch (verify + one test): one line — the named postcondition is the source version field; the existing verify gate claimed version consistency but only after overwrite.

## Done-when (oracle, named at source)

Parsed `src/extension/manifest.json` `version` is `"3.0.1"` and equals `package.json` `version`.

At `candidate_sha` `8d4a4dbb1867223bd05ed601e50e46b01938718b`:

```text
source 3.0.1
package 3.0.1
chrome dist 3.0.1
firefox dist 3.0.1
```

`bun run verify` reports `source chrome manifest version == 3.0.1`.

Consent remains gated: `tests/page-runner.test.ts` `PageRunner — consent gate` still refuses a destructive run without consent (`ConsentRequiredError`) and runs only after `acknowledgeConsent()`. Untouched files: `src/core/page-runner.ts`, `src/extension/content.ts`, popup/panel consent UI.

## Evidence layer

Source / local tests. Not CI, not landed, not live-browser, not store.

Run locally at `candidate_sha` (`8d4a4dbb1867223bd05ed601e50e46b01938718b`, working tree clean of tracked files):

- `bun run typecheck` — pass
- `bun run lint` — pass
- `bun run test` — 210 passed (17 files), including new `source manifest version equals package version`
- `bun run build` — pass (Chrome + Firefox extension, standalone, userscript)
- `bun run listing:check` — pass (`listing.appliesTo (3.0.1) == package version (3.0.1)`)
- `bun run verify` — pass, including `source chrome manifest version == 3.0.1`
- targeted: `tests/surface.test.ts`, `tests/ui-wiring.test.ts`, `tests/page-runner.test.ts` — 34 passed

No live Google Photos session; no destructive action was performed.

## Triggered floors

```text
Outcome: src/extension/manifest.json version is 3.0.1 on writer default
Applicable clause: standards/PRINCIPLES.md Correctness
Trigger: every write/effect
Product mapping: shtse8/Google-Photos-Delete-Tool src/extension/manifest.json version field
Oracle: JSON.parse(src/extension/manifest.json).version !== "3.0.1"
Gap or exception: none
```

```text
Outcome: source manifest version stays aligned with package.json
Applicable clause: standards/proof.md Postcondition, not proxy
Trigger: this set writes a test / named oracle
Product mapping: tests/surface.test.ts and scripts/verify.ts parse the version field
Oracle: parsed source version !== parsed package.json version
Gap or exception: none
```

`standards/exceptions.md` owning-writer: no fact crosses a second writer.
`standards/dogfood.md`: not triggered (no sold job, first-party path, or sibling call in this set).

## Harm classification (ordinary; lease challenge verifies)

Admitted ordinary. `standards/work.md` names deletion as a high-harm surface; this SHA does **not** touch deletion, consent, engine, empty-trash, store publish, migrations, money, identity, or irreversible rollout. It changes one version string plus two version-field parsers. Lease challenge should fail this set if it actually touched a high-harm surface.

## Ready self-judge (ordinary)

Attempted disconfirmation against `8d4a4dbb1867223bd05ed601e50e46b01938718b`:

| Check | Result | Evidence |
| --- | --- | --- |
| Disputed fate | pass | dest docs untouched; GPDT-CONSENT remains `live` |
| Dest-lock folded with execution | pass | no `docs/vision.md` / `docs/capabilities.md` edit |
| Wrong-layer workaround | pass | source file is the named layer; no live/store substitute |
| Backdoor / self-privilege | pass | no privileged path; permissions still `["storage"]` |
| Proxy pin | pass | oracles parse the public manifest `version` field vs package version; they fail when the field is wrong, not when a comment/token is present |
| Mis-owned result | pass | writer is `shtse8/Google-Photos-Delete-Tool`; worktree `/tmp/owner-admit/gpdt_manifest`; no company dest, no sibling `RELEASE_GATE` observe files |
| Lost data | pass | version string only; no storage/schema change |
| Second writer | pass | no Keel tip, no Cubloom GOV-008, no `find_edge/gpdt` write |
| Omitted shared contract | pass | no shared-meaning schema in set |
| Expand sold as done | pass | claim is source version 3.0.1, not store-live 3.0.1 |
| Reversed cutover | pass | no cutover |
| Tests-only claimed as customer Done when | pass | production file `src/extension/manifest.json` changes; tests accompany |
| Consent still gated | pass | `ConsentRequiredError` without acknowledgement; consent source files not in diff |
| Workarounds left in | pass | none |

## Recovery

Revert this PR / drop this branch. No data migration, no live writer, no store publish. Built artifacts already took version from `package.json`; this restores source/package agreement.

## Next action

Lease challenge of this ordinary Ready SHA. Do not merge from this Worker. The forge waits.

- base: `master@b1805521c2036d6fe44c9577509937f78fcd1b86`
