### PR TITLE
docs: dest-lock store locators to live CWS 3.0.1

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -88,27 +88,48 @@ of current truth only. This is a personal product under the `shtse8`
 organisation; its real boundary is store listings and browser scripts, not
 company delivery vocabulary.
 
-- **Public probe.** The published store listing is the cheapest falsifiable
-  customer-visible proof at this product's boundary: the Chrome Web Store
-  listing
+- **Public probe.** The cheapest falsifiable customer-visible proof at this
+  product's boundary is the published Chrome Web Store listing
   `https://chromewebstore.google.com/detail/google-photos-delete-tool/jiahfbbfpacpolomdjlpdpiljllcdenb`
-  (plus the Edge Add-ons, Firefox AMO, and Greasy Fork listings) shows the
-  version a customer can actually install, and the `store-state` branch
-  (`state.json`) records what is live per store — advanced only after the
-  platform API confirms a publish. A green CI run or a GitHub Release asset
-  alone is not proof a store version is live, and per `RELEASE_GATE.md` only
-  a real disposable-account run against Google Photos proves the release.
+  (item `jiahfbbfpacpolomdjlpdpiljllcdenb`). Attested 2026-09-04: HTTP 200,
+  listing Version `3.0.1`, Add to Chrome present; `store-state` records
+  `cws: "v3.0.1"`; Chrome update XML for that id returns `noupdate`;
+  shields.io `chrome-web-store/v` reports `v3.0.1`. A store `200` is not
+  the product contract. Per `RELEASE_GATE.md`, only a real disposable-account
+  run against Google Photos proves a live-product claim.
+
+  Dest-retracted locators (unpublished; not customer doors):
+  - Firefox AMO dest slug
+    `https://addons.mozilla.org/en-US/firefox/addon/google-photos-delete-tool/`
+    — HTTP 404, AMO API v5 `{"detail":"Not found."}`, search `shtse8`
+    count 0. `store-state` `amo: null`. store-retry skips AMO:
+    `FIREFOX_JWT_ISSUER` / `FIREFOX_JWT_SECRET` not configured.
+  - Microsoft Edge Add-ons — `store-state` `edge: null`;
+    `getproductdetailsbycrxid/jiahfbbfpacpolomdjlpdpiljllcdenb` HTTP 404.
+    store-retry skips Edge: `EDGE_CLIENT_ID` / `EDGE_API_KEY` /
+    `EDGE_PRODUCT_ID` not configured.
+  - Greasy Fork dest slug
+    `https://greasyfork.org/en/scripts/google-photos-delete-tool`
+    — HTTP 404 (`404 - Page Not Found`). Userscript locator is the GitHub
+    release asset
+    `https://github.com/shtse8/Google-Photos-Delete-Tool/releases/download/v3.0.1/google-photos-delete.user.js`.
+
+  The `store-state` branch (`state.json`) records what is live per store —
+  advanced only after the platform API confirms a publish. A green CI run or
+  a GitHub Release asset alone is not proof a store version is live.
 - **Owned manifest/migration writers.** Store pipelines are the release
   writers: `release.yml` on `v*` tags builds, verifies artifacts, and creates
   the GitHub Release (the source-of-truth assets); `store-retry.yml` (6-hour
   cron) drives `store-publish.yml`, which uploads and publishes the package
-  to Chrome Web Store, Edge Add-ons, and Firefox AMO via each store's API;
-  `update-cws-listing.yml` pushes CWS listing metadata from
+  to Chrome Web Store via its API. Edge Add-ons and Firefox AMO jobs in the
+  same workflow currently skip (`EDGE_*` / `FIREFOX_JWT_*` secrets not
+  configured) and are not dest locators until a publish is recorded in
+  `store-state`; `update-cws-listing.yml` pushes CWS listing metadata from
   `storefront/listing.json`; `bootstrap-amo.yml` is a one-time AMO add-on
-  creation; Greasy Fork (userscript) is human-once, and the script updates
-  itself afterwards. Store dashboards are consumers of
-  `storefront/listing.json`, never a second source. Migration writer: none —
-  there is no database and no migration.
+  creation that has not produced a live listing; Greasy Fork (userscript) is
+  unpublished (dest slug 404) and is not a customer locator. Store dashboards
+  are consumers of `storefront/listing.json`, never a second source.
+  Migration writer: none — there is no database and no migration.
 - **Consumed receipts.** GitHub Actions run receipts and GitHub Release
   assets; store-platform publish confirmations (CWS, Edge, AMO) recorded in
   the `store-state` branch; store review queues (`ITEM_NOT_UPDATABLE` on

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -47,9 +47,12 @@ The customer contract is:
 
 - The product acts only on `photos.google.com`. It is not a Google Photos API
   client, downloader, multi-site automation service, or unattended scheduler.
-- Supported customer surfaces are the Chrome/Firefox extension and the
-  userscript. The standalone build is a development artifact, not a third
-  supported product surface.
+- Supported runtime surfaces are the Chromium/Firefox MV3 extension and the
+  userscript. Customer-installable locators are the Chrome Web Store listing
+  and the GitHub release userscript. Firefox AMO, Microsoft Edge Add-ons, and
+  Greasy Fork listings are unpublished and are not dest locators. The
+  standalone build is a development artifact, not a third supported product
+  surface.
 - The deletion engine, dry run, and optional empty-trash flow are the core
   product. Local Pro licensing may unlock analysis and filters, but it must not
   weaken the destructive-action contract.


### PR DESCRIPTION
## Outcome

Store locators dest-honest. Unpublished AMO, Edge, and Greasy Fork doors are dest-retracted. Chrome Web Store is attested live at Version 3.0.1. No second store path invented.

## Bind

- **Identity:** GOV-017 public probe / dest locators. Graph IDs (GPDT-ENTER through GPDT-EVIDENCE) unchanged; fates remain live.
- **Fate:** dest-lock locators to live truth.
- **Destination revision:** docs/vision.md and docs/capabilities.md at master f6c476e706.
- **Write/effect:** dest-lock those two files so dest does not imply unpublished listings are published.
- **Oracle:** live HTTP/API probes of CWS, AMO, Edge, Greasy Fork, store-state, and store-retry 33873804530.
- **Layer:** docs (product dest). Source, listing copy, and store secrets unchanged.
- **Recovery:** if AMO/Edge/Greasy Fork later publish, dest-lock those locators back in with the live URL and version. If CWS version changes, dest-lock the attested version.

## Listing evidence (2026-09-04)

| Locator | Dest claim before | Live |
| --- | --- | --- |
| CWS https://chromewebstore.google.com/detail/google-photos-delete-tool/jiahfbbfpacpolomdjlpdpiljllcdenb (item jiahfbbfpacpolomdjlpdpiljllcdenb) | listing exists | HTTP 200; listing HTML Version 3.0.1; Add to Chrome present; Updated August 10, 2026; shields.io v3.0.1; Chrome update XML noupdate; store-state cws: "v3.0.1" |
| AMO https://addons.mozilla.org/en-US/firefox/addon/google-photos-delete-tool/ | dest listed | HTTP 404; AMO API v5 {"detail":"Not found."}; search shtse8 count 0; store-state amo: null |
| Edge getproductdetailsbycrxid/jiahfbbfpacpolomdjlpdpiljllcdenb | dest listed | HTTP 404; store-state edge: null |
| Greasy Fork https://greasyfork.org/en/scripts/google-photos-delete-tool | dest listed | HTTP 404 (404 - Page Not Found) |
| Userscript | implied Greasy Fork | GitHub release asset https://github.com/shtse8/Google-Photos-Delete-Tool/releases/download/v3.0.1/google-photos-delete.user.js |

store-retry https://github.com/shtse8/Google-Photos-Delete-Tool/actions/runs/33873804530 (head f6c476e706, 2026-09-04T12:38Z): target=v3.0.1 pending=[edge,amo]; CWS job skipped (already at tag); AMO skipped FIREFOX_JWT_ISSUER / FIREFOX_JWT_SECRET not configured; Edge skipped EDGE_CLIENT_ID / EDGE_API_KEY / EDGE_PRODUCT_ID not configured.

CWS ITEM_NOT_UPDATABLE is not the current live-listing blocker. The listing is Version 3.0.1. This set dest-retracts unpublished locators rather than inventing AMO/Edge/Greasy Fork publish paths.

## Remaining False

- GPDT-EVIDENCE (destructive live-run on a disposable Google Photos account): remaining False. This set dest-locks locators; dest still requires RELEASE_GATE.md for any live-product claim. A store 200 is not that oracle.

## Floors

- Correctness (standards/PRINCIPLES.md): dest locators must match live doors. Oracle: dest still naming AMO/Edge/Greasy Fork as customer listings.
- docs.md dest-lock: vision + capabilities in one PR.
- work.md public contracts: dest locators are public. Assignment classified ordinary. Lease challenge verifies harm class; independent judge-sha if public-contracts is treated high-harm.
- proof.md: no new test/CI gate. Oracle is the live listing probes above.
- dogfood.md: not triggered (no sold job / first-party use in this set).

## Ordinary self-judge (assignment harm)

- Proxy pin? No. Dest-lock is not a CI-green substitute for live listings.
- Self-privilege? No.
- Mis-owned result? Writer is shtse8/Google-Photos-Delete-Tool. No SylphxAI/owner write.
- Lost data? Retracts unpublished locators only.
- Second writer? No.

## Candidate

candidate_sha: 5eb3cd366831fe35a2c05753413958c78fc8b7af
