### PR TITLE
feat(core): keep a run under present user control (GPDT-CONTROL)

### DIFF
--- a/src/core/delete-engine.ts
+++ b/src/core/delete-engine.ts
@@ -481,6 +481,7 @@ export class DeleteEngine {
     while (remaining > 0) {
       await this.awaitControl()
       await this.dom.sleep(pollMs)
+      await this.awaitControl()
       remaining -= pollMs
       this.harvestVisibleIds(seen, onWarn)
     }
@@ -538,9 +539,11 @@ export class DeleteEngine {
     while (remaining > 0) {
       await this.awaitControl()
       await this.dom.sleep(pollMs)
+      await this.awaitControl()
       remaining -= pollMs
       this.harvestVisibleIds(seen, onWarn)
     }
+    await this.awaitControl()
     this.harvestVisibleIds(seen, onWarn)
 
     const scrolled = target.scrollTop > beforeTop || target.scrollHeight > beforeHeight
@@ -639,6 +642,7 @@ export class DeleteEngine {
       clicked += candidates.length
       if (clicked >= maxToSelect) break
       await this.dom.sleep(50)
+      await this.awaitControl()
       settleRemaining -= 50
     }
 
@@ -681,6 +685,7 @@ export class DeleteEngine {
       await this.awaitControl()
       const slice = Math.min(this.config.pollDelay, 200)
       await this.dom.sleep(slice)
+      await this.awaitControl()
       settleRemaining -= slice
       const after = measure()
       const movedScroll = after.top > before.top
@@ -800,6 +805,7 @@ export class DeleteEngine {
         throw new Error(`Timed out after ${timeoutMs}ms: ${what}`)
       }
       await this.dom.sleep(this.config.pollDelay)
+      await this.awaitControl()
       remaining -= this.config.pollDelay
     }
   }

--- a/src/core/delete-engine.ts
+++ b/src/core/delete-engine.ts
@@ -5,16 +5,11 @@ import { shouldSelectTile, type PhotoFilter } from './photo-filter'
 import { diagnostics } from './diagnostics'
 import type { RunStatus } from './status'
 import { describeButton } from './utils'
+import { StopRequested } from './run-occupancy'
+
+export { StopRequested }
 
 const LOG = '[gpdt]'
-
-/** Thrown internally when the user requests a stop mid-wait. */
-export class StopRequested extends Error {
-  constructor() {
-    super('stop requested')
-    this.name = 'StopRequested'
-  }
-}
 
 export interface Progress {
   /** Photos actually moved to Trash. Always 0 for a dry-run scan — a preview never mutates. */
@@ -208,8 +203,7 @@ export class DeleteEngine {
 
     try {
       while (!this.stopped) {
-        await this.checkPause()
-        if (this.stopped) break
+        await this.awaitControl()
 
         // Phase 1: select what's visible (up to the effective batch cap).
         const beforeCount = this.getCount()
@@ -259,7 +253,7 @@ export class DeleteEngine {
             break
           }
           // Brief pause before retrying — the page might just be slow.
-          await this.dom.sleep(this.config.pollDelay)
+          await this.sleepControlled(this.config.pollDelay)
         } else {
           if (consecutiveNoProgress > 0) {
             console.log(
@@ -362,25 +356,25 @@ export class DeleteEngine {
     this.progress.status = 'scrolling'
     this.emitProgress()
 
-    // Start from the top — running a dry-run from mid-gallery would
-    // skip everything above the viewport otherwise.
-    const target = this.dom.findScrollTarget()
-    if (target) {
-      target.scrollTo({ top: 0, left: 0, behavior: 'auto' })
-      await this.dom.sleep(this.config.scrollSettleMs)
-    }
-
-    // Initial harvest at the top before we touch the scroll target.
-    // The deduplicated Set size is a browser observation → progress.total.
-    // progress.deleted stays 0: nothing has been (or will be) deleted.
-    this.harvestVisibleIds(seen, (warned) => { missingIdWarned = warned })
-    this.progress.total = seen.size
-    this.emitProgress()
-
     try {
+      // Start from the top — running a dry-run from mid-gallery would
+      // skip everything above the viewport otherwise. The settle wait
+      // is inside the try so a user stop still resolves idle.
+      const target = this.dom.findScrollTarget()
+      if (target) {
+        target.scrollTo({ top: 0, left: 0, behavior: 'auto' })
+        await this.sleepControlled(this.config.scrollSettleMs)
+      }
+
+      // Initial harvest at the top before we touch the scroll target.
+      // The deduplicated Set size is a browser observation → progress.total.
+      // progress.deleted stays 0: nothing has been (or will be) deleted.
+      this.harvestVisibleIds(seen, (warned) => { missingIdWarned = warned })
+      this.progress.total = seen.size
+      this.emitProgress()
+
       while (!this.stopped) {
-        await this.checkPause()
-        if (this.stopped) break
+        await this.awaitControl()
 
         const before = seen.size
         const heightBefore = target?.scrollHeight ?? 0
@@ -415,7 +409,7 @@ export class DeleteEngine {
             console.log(`${LOG} [dry-run] end of gallery — final count: ${seen.size}`)
             break
           }
-          await this.dom.sleep(this.config.pollDelay)
+          await this.sleepControlled(this.config.pollDelay)
         } else if (scrolled && gained === 0 && !heightGrew) {
           // Scrolled past content but found nothing new and the page
           // isn't lazy-loading more. After two such windows, done.
@@ -483,9 +477,11 @@ export class DeleteEngine {
   private async finalDryRunSettle(seen: Set<string>, onWarn: (missing: boolean) => void): Promise<void> {
     const beforeSize = seen.size
     const pollMs = Math.min(this.config.pollDelay, 200)
-    const settleDeadline = Date.now() + 2000
-    while (Date.now() < settleDeadline && !this.stopped) {
+    let remaining = 2000
+    while (remaining > 0) {
+      await this.awaitControl()
       await this.dom.sleep(pollMs)
+      remaining -= pollMs
       this.harvestVisibleIds(seen, onWarn)
     }
     if (seen.size > beforeSize) {
@@ -536,10 +532,13 @@ export class DeleteEngine {
     target.scrollBy({ top: step, left: 0, behavior: 'auto' })
 
     // Poll for the duration of scrollSettleMs, harvesting at every poll.
+    // Pause does not burn the settle budget — it holds the scan.
     const pollMs = Math.min(this.config.pollDelay, 200)
-    const start = Date.now()
-    while (Date.now() - start < this.config.scrollSettleMs) {
+    let remaining = this.config.scrollSettleMs
+    while (remaining > 0) {
+      await this.awaitControl()
       await this.dom.sleep(pollMs)
+      remaining -= pollMs
       this.harvestVisibleIds(seen, onWarn)
     }
     this.harvestVisibleIds(seen, onWarn)
@@ -556,11 +555,23 @@ export class DeleteEngine {
 
   // ─── Private helpers ───────────────────────────────────────────
 
-  /** Wait while paused (resolves on resume or stop). */
-  private async checkPause(): Promise<void> {
+  /**
+   * Yield to pause/stop. Stop throws {@link StopRequested} so the run
+   * resolves idle; pause holds until resume continues this same engine.
+   */
+  private async awaitControl(): Promise<void> {
+    if (this.stopped) throw new StopRequested()
     if (this.pausePromise) {
       await this.pausePromise
     }
+    if (this.stopped) throw new StopRequested()
+  }
+
+  /** Sleep that still yields to pause/stop before and after. */
+  private async sleepControlled(ms: number): Promise<void> {
+    await this.awaitControl()
+    await this.dom.sleep(ms)
+    await this.awaitControl()
   }
 
   private emitProgress(): void {
@@ -611,10 +622,12 @@ export class DeleteEngine {
   private async selectVisibleCheckboxes(maxToSelect: number): Promise<number> {
     if (maxToSelect <= 0) return 0
 
-    const deadline = Date.now() + this.config.selectionSettleMs
+    // Budget is wave-settle time, not wall-clock: pause must not eat it.
+    let settleRemaining = this.config.selectionSettleMs
     let clicked = 0
 
-    while (Date.now() < deadline && clicked < maxToSelect) {
+    while (settleRemaining > 0 && clicked < maxToSelect) {
+      await this.awaitControl()
       const remaining = maxToSelect - clicked
       const candidates = this.dom.uncheckedTiles()
         .filter(tile => shouldSelectTile(tile.label(), this.filter))
@@ -626,10 +639,13 @@ export class DeleteEngine {
       clicked += candidates.length
       if (clicked >= maxToSelect) break
       await this.dom.sleep(50)
+      settleRemaining -= 50
     }
 
     // Final settle so the counter reflects the last wave.
+    await this.awaitControl()
     await this.dom.sleep(50)
+    await this.awaitControl()
     console.log(
       `${LOG} selected ${clicked} new item(s) ` +
       `(counter: ${this.getCount()}, filter: ${JSON.stringify(this.filter)})`,
@@ -654,13 +670,18 @@ export class DeleteEngine {
       checkboxes: this.dom.uncheckedTiles().length,
     })
 
+    await this.awaitControl()
+
     const before = measure()
     const step = Math.max(200, target.clientHeight || 800)
     target.scrollBy({ top: step, left: 0, behavior: 'auto' })
 
-    const start = Date.now()
-    while (Date.now() - start < this.config.scrollSettleMs) {
-      await this.dom.sleep(Math.min(this.config.pollDelay, 200))
+    let settleRemaining = this.config.scrollSettleMs
+    while (settleRemaining > 0) {
+      await this.awaitControl()
+      const slice = Math.min(this.config.pollDelay, 200)
+      await this.dom.sleep(slice)
+      settleRemaining -= slice
       const after = measure()
       const movedScroll = after.top > before.top
       const grewHeight = after.height > before.height
@@ -770,18 +791,16 @@ export class DeleteEngine {
     timeoutMs: number,
     what: string,
   ): Promise<NonNullable<T>> {
-    const start = Date.now()
+    let remaining = timeoutMs
     while (true) {
-      if (this.stopped) throw new StopRequested()
+      await this.awaitControl()
       const result = condition()
       if (result) return result as NonNullable<T>
-      if (Date.now() - start >= timeoutMs) {
+      if (remaining <= 0) {
         throw new Error(`Timed out after ${timeoutMs}ms: ${what}`)
       }
-      if (this.paused) {
-        await this.pausePromise
-      }
       await this.dom.sleep(this.config.pollDelay)
+      remaining -= this.config.pollDelay
     }
   }
 }

--- a/src/core/empty-trash.ts
+++ b/src/core/empty-trash.ts
@@ -9,6 +9,7 @@
  * A "done" without proof is never emitted for a permanent action.
  */
 import { describeButton } from './utils'
+import { StopRequested } from './run-occupancy'
 /**
  * Status the flow reports as it progresses.
  */
@@ -73,7 +74,8 @@ export async function runEmptyTrashFlow(deps: EmptyTrashDeps): Promise<void> {
     let btn: HTMLElement
     try {
       btn = await deps.waitFor(deps.findEmptyTrashButton, t.findButton)
-    } catch {
+    } catch (err) {
+      if (err instanceof StopRequested) throw err
       // The trash may already be empty — resolve to done instead of error.
       if (deps.isTrashEmpty()) {
         log('trash already empty')
@@ -103,7 +105,8 @@ export async function runEmptyTrashFlow(deps: EmptyTrashDeps): Promise<void> {
         () => (!deps.findEmptyTrashButton() && !deps.findConfirmDialog()) || deps.isTrashEmpty(),
         t.postConfirm,
       )
-    } catch {
+    } catch (err) {
+      if (err instanceof StopRequested) throw err
       throw new Error(
         'Empty trash may not have completed: the toolbar still shows an empty action. ' +
         'Please verify /trash manually before assuming photos are gone.',
@@ -113,6 +116,7 @@ export async function runEmptyTrashFlow(deps: EmptyTrashDeps): Promise<void> {
     onStatus('done')
     log('trash emptied (postcondition verified)')
   } catch (err) {
+    if (err instanceof StopRequested) throw err
     const msg = err instanceof Error ? err.message : String(err)
     log(`empty-trash failed: ${msg}`)
     onStatus('error', { error: `Empty trash failed: ${msg}` })

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -30,6 +30,12 @@ export {
   type Progress,
   type EngineOptions,
 } from './delete-engine'
+export {
+  RunInProgressError,
+  RUN_IN_PROGRESS_MESSAGE,
+  isRunOccupied,
+  waitUntilAbortable,
+} from './run-occupancy'
 export { sleep, waitUntil, formatElapsed, formatEta, describeButton } from './utils'
 export { DeletionLog, type DeletionEntry } from './deletion-log'
 export type { EngineDom, ClickTarget, ScrollTarget, PhotoTile } from './dom-adapter'

--- a/src/core/page-runner.ts
+++ b/src/core/page-runner.ts
@@ -10,9 +10,9 @@ import { DeleteEngine, type Progress } from './delete-engine'
 import { browserDom } from './browser-dom'
 import type { EngineDom } from './dom-adapter'
 import { createLocalStorageBaton, evaluatePendingEmptyTrash, TRASH_URL, type EmptyTrashBaton } from './empty-trash-baton'
-import { runEmptyTrashFlow, type EmptyTrashStatus } from './empty-trash'
+import { runEmptyTrashFlow, type EmptyTrashDeps, type EmptyTrashStatus } from './empty-trash'
 import { findConfirmButton, findConfirmDialog, findEmptyTrashButton, isTrashEmpty } from './selectors'
-import { sleep, waitUntil } from './utils'
+import { sleep } from './utils'
 import { buildDiagnosticIssueUrl, diagnostics } from './diagnostics'
 import { verifyLicense } from './license'
 import { classifyLabel, type PhotoFilter, type PhotoType } from './photo-filter'
@@ -27,8 +27,10 @@ import {
   throwForDestructiveRefusal,
   writeLocalAcknowledgement,
 } from './consent'
+import { RunInProgressError, StopRequested, waitUntilAbortable } from './run-occupancy'
 
 export { ConsentRequiredError, PermanentActionRequiredError } from './consent'
+export { RunInProgressError }
 
 export interface PanelRunOptions {
   maxCount: number
@@ -51,18 +53,33 @@ export interface DryRunSummary {
 
 const LICENSE_KEY = 'gpdt_pro_token_v3'
 
+type EmptyTrashHost = (deps: Pick<EmptyTrashDeps, 'waitFor' | 'sleep' | 'log' | 'onStatus'>) => Promise<void>
+
 export class PageRunner {
   private engine: DeleteEngine | null = null
   private running = false
+  private emptyTrashStopped = false
   private progress: Progress | null = null
   private statusListeners = new Set<(s: RunnerStatus) => void>()
   private summary: DryRunSummary | null = null
   private readonly dom: EngineDom
   private readonly baton: EmptyTrashBaton
+  private readonly runEmptyTrash: EmptyTrashHost
 
-  constructor(opts: { dom?: EngineDom; baton?: EmptyTrashBaton } = {}) {
+  constructor(opts: {
+    dom?: EngineDom
+    baton?: EmptyTrashBaton
+    runEmptyTrash?: EmptyTrashHost
+  } = {}) {
     this.dom = opts.dom ?? browserDom
     this.baton = opts.baton ?? createLocalStorageBaton()
+    this.runEmptyTrash = opts.runEmptyTrash ?? ((deps) => runEmptyTrashFlow({
+      findEmptyTrashButton,
+      findConfirmDialog,
+      findConfirmButton,
+      isTrashEmpty,
+      ...deps,
+    }))
   }
 
   // ─── Status broadcast ─────────────────────────────────────────
@@ -158,7 +175,7 @@ export class PageRunner {
   // ─── Run lifecycle ────────────────────────────────────────────
 
   async start(opts: PanelRunOptions): Promise<void> {
-    if (!admitConcurrentStart(this.running).ok) return
+    if (!admitConcurrentStart(this.running).ok) throw new RunInProgressError()
     const admission = admitDestructiveRun({
       dryRun: opts.dryRun,
       emptyTrashAfter: opts.emptyTrashAfter,
@@ -225,6 +242,7 @@ export class PageRunner {
 
   stop(): void {
     this.engine?.stop()
+    this.emptyTrashStopped = true
   }
 
   getSummary(): DryRunSummary | null {
@@ -252,31 +270,52 @@ export class PageRunner {
    * fresh AND on /trash (see evaluatePendingEmptyTrash).
    */
   async maybeRunPendingEmptyTrash(): Promise<void> {
+    if (this.running) return
+
     const pending = await this.baton.readPending()
     await this.baton.clearPending()
     const evalResult = evaluatePendingEmptyTrash(pending, Date.now(), this.dom.pathname)
     if (!evalResult.shouldRun) return
 
+    if (this.emptyTrashStopped) {
+      this.emptyTrashStopped = false
+      return
+    }
+
+    this.running = true
     this.setProgress({ deleted: 0, selected: 0, status: 'emptyingTrash', startedAt: Date.now() })
-    await runEmptyTrashFlow({
-      findEmptyTrashButton,
-      findConfirmDialog,
-      findConfirmButton,
-      isTrashEmpty,
-      waitFor: (cond, timeoutMs) => waitUntil(cond, timeoutMs, 400),
-      sleep,
-      log: (msg) => console.log(`[gpdt:runner] ${msg}`),
-      onStatus: (status: EmptyTrashStatus, extra?: { error?: string }) => {
+    try {
+      await this.runEmptyTrash({
+        waitFor: (cond, timeoutMs) =>
+          waitUntilAbortable(cond, timeoutMs, 400, () => this.emptyTrashStopped),
+        sleep,
+        log: (msg) => console.log(`[gpdt:runner] ${msg}`),
+        onStatus: (status: EmptyTrashStatus, extra?: { error?: string }) => {
+          this.setProgress({
+            deleted: 0,
+            selected: 0,
+            status: status as RunStatus,
+            startedAt: Date.now(),
+            error: extra?.error,
+          })
+        },
+      })
+    } catch (err) {
+      if (err instanceof StopRequested) {
         this.setProgress({
           deleted: 0,
           selected: 0,
-          status: status as RunStatus,
+          status: 'idle',
           startedAt: Date.now(),
-          error: extra?.error,
         })
-      },
-    }).catch(() => { /* already reported via onStatus */ })
-    this.emit()
+        return
+      }
+      /* already reported via onStatus */
+    } finally {
+      this.running = false
+      this.emptyTrashStopped = false
+      this.emit()
+    }
   }
 
   // ─── Diagnostics / issue reports ──────────────────────────────

--- a/src/core/page-runner.ts
+++ b/src/core/page-runner.ts
@@ -282,6 +282,10 @@ export class PageRunner {
       return
     }
 
+    // Re-check after baton I/O: a start may have occupied the slot
+    // while we were reading. Do not start empty-trash, and do not
+    // clear the live start's occupancy in finally.
+    if (this.running) return
     this.running = true
     this.setProgress({ deleted: 0, selected: 0, status: 'emptyingTrash', startedAt: Date.now() })
     try {

--- a/src/core/run-occupancy.ts
+++ b/src/core/run-occupancy.ts
@@ -1,0 +1,69 @@
+/**
+ * One run slot per supported surface (GPDT-CONTROL).
+ *
+ * A second start is refused while an engine, its settling tail, a start
+ * handshake, or an empty-trash flow occupies the slot. StopRequested is
+ * the shared abort signal so a user stop during an action wait resolves
+ * to idle rather than error.
+ */
+import { sleep } from './utils'
+
+/** Thrown internally when the user requests a stop mid-wait. */
+export class StopRequested extends Error {
+  constructor() {
+    super('stop requested')
+    this.name = 'StopRequested'
+  }
+}
+
+export const RUN_IN_PROGRESS_MESSAGE =
+  'A run is already in progress — stop it first.'
+
+export class RunInProgressError extends Error {
+  constructor() {
+    super(RUN_IN_PROGRESS_MESSAGE)
+    this.name = 'RunInProgressError'
+  }
+}
+
+export function isRunOccupied(flags: {
+  engine?: unknown
+  runPromise?: unknown
+  starting?: boolean
+  emptying?: boolean
+  running?: boolean
+}): boolean {
+  return Boolean(
+    flags.engine ||
+      flags.runPromise ||
+      flags.starting ||
+      flags.emptying ||
+      flags.running,
+  )
+}
+
+/**
+ * Poll `condition` until truthy. Throws {@link StopRequested} as soon as
+ * `isStopped` is true, and throws a timeout error if `timeout` elapses
+ * without a stop. Pause/hold is the caller's job: do not call this while
+ * the user has asked the engine to pause — empty-trash has no pause.
+ */
+export async function waitUntilAbortable<T>(
+  condition: () => T | Promise<T>,
+  timeout: number,
+  pollDelay: number,
+  isStopped: () => boolean,
+  sleepFn: (ms: number) => Promise<void> = sleep,
+): Promise<NonNullable<T>> {
+  let remaining = timeout
+  while (true) {
+    if (isStopped()) throw new StopRequested()
+    const result = await condition()
+    if (result) return result as NonNullable<T>
+    if (remaining <= 0) {
+      throw new Error(`Timed out after ${timeout}ms`)
+    }
+    await sleepFn(pollDelay)
+    remaining -= pollDelay
+  }
+}

--- a/src/core/run-occupancy.ts
+++ b/src/core/run-occupancy.ts
@@ -64,6 +64,7 @@ export async function waitUntilAbortable<T>(
       throw new Error(`Timed out after ${timeout}ms`)
     }
     await sleepFn(pollDelay)
+    if (isStopped()) throw new StopRequested()
     remaining -= pollDelay
   }
 }

--- a/src/extension/content.ts
+++ b/src/extension/content.ts
@@ -20,7 +20,7 @@ import { DEFAULT_CONFIG, DeleteEngine, type Progress } from '../core'
 import type { PhotoFilter } from '../core/photo-filter'
 import { browserDom } from '../core/browser-dom'
 import { findConfirmButton, findConfirmDialog, findEmptyTrashButton, isTrashEmpty } from '../core/selectors'
-import { sleep, waitUntil } from '../core/utils'
+import { sleep } from '../core/utils'
 import { diagnostics } from '../core/diagnostics'
 import { evaluatePendingEmptyTrash, TRASH_URL } from '../core/empty-trash-baton'
 import { runEmptyTrashFlow, type EmptyTrashStatus } from '../core/empty-trash'
@@ -36,6 +36,11 @@ import {
   shouldNavigateToEmptyTrash,
   type Acknowledgement,
 } from '../core/consent'
+import {
+  isRunOccupied,
+  StopRequested,
+  waitUntilAbortable,
+} from '../core/run-occupancy'
 import { createChromeBaton, runtimeSendMessage, storageGet, storageRemove, storageSet } from './api'
 
 const LOG = '[gpdt:content]'
@@ -62,6 +67,8 @@ async function readChromeAcknowledgement(key: string): Promise<Acknowledgement> 
 let engine: DeleteEngine | null = null
 let runPromise: Promise<void> | null = null
 let starting = false
+let emptying = false
+let emptyTrashStopped = false
 
 interface StartOptions {
   maxCount?: number
@@ -74,7 +81,7 @@ const start = async (opts: StartOptions): Promise<{ ok: boolean; error?: string 
   if (!isSupportedPhotosUrl(window.location.href)) {
     return { ok: false, error: 'Not on photos.google.com.' }
   }
-  if (!admitConcurrentStart(engine !== null || runPromise !== null || starting).ok) {
+  if (!admitConcurrentStart(isRunOccupied({ engine, runPromise, starting, emptying })).ok) {
     return { ok: false, error: RUN_IN_PROGRESS_ERROR }
   }
   starting = true
@@ -146,9 +153,11 @@ const stop = (): void => {
   // Keep `engine` non-null until the run promise settles so a new Start
   // cannot race the tail of a stopped run. The engine resolves 'idle'.
   engine?.stop()
+  emptyTrashStopped = true
 }
 
-const isRunning = (): boolean => engine !== null && !engine.isStopped
+const isRunning = (): boolean =>
+  emptying || (engine !== null && !engine.isStopped)
 
 // ─── Empty-trash chain (after a clean real run) ─────────────────
 
@@ -209,20 +218,34 @@ async function maybeRunPendingEmptyTrash(): Promise<void> {
   await baton.clearPending()
   const evalResult = evaluatePendingEmptyTrash(pending, Date.now(), window.location.pathname)
   if (!evalResult.shouldRun) return
+  if (emptyTrashStopped) return
 
+  emptying = true
   sendStatus('emptyingTrash')
-  await runEmptyTrashFlow({
-    findEmptyTrashButton,
-    findConfirmDialog,
-    findConfirmButton,
-    isTrashEmpty,
-    waitFor: (cond, timeoutMs) => waitUntil(cond, timeoutMs, 400),
-    sleep,
-    log: (msg) => console.log(`${LOG} ${msg}`),
-    onStatus: (status: EmptyTrashStatus, extra?: { error?: string }) => {
-      sendStatus(status, extra)
-    },
-  }).catch(() => { /* already reported via onStatus */ })
+  try {
+    await runEmptyTrashFlow({
+      findEmptyTrashButton,
+      findConfirmDialog,
+      findConfirmButton,
+      isTrashEmpty,
+      waitFor: (cond, timeoutMs) =>
+        waitUntilAbortable(cond, timeoutMs, 400, () => emptyTrashStopped),
+      sleep,
+      log: (msg) => console.log(`${LOG} ${msg}`),
+      onStatus: (status: EmptyTrashStatus, extra?: { error?: string }) => {
+        sendStatus(status, extra)
+      },
+    })
+  } catch (err) {
+    if (err instanceof StopRequested) {
+      sendStatus('idle')
+      return
+    }
+    /* already reported via onStatus */
+  } finally {
+    emptying = false
+    emptyTrashStopped = false
+  }
 }
 
 // ─── Progress reporting ─────────────────────────────────────────

--- a/src/extension/content.ts
+++ b/src/extension/content.ts
@@ -219,6 +219,7 @@ async function maybeRunPendingEmptyTrash(): Promise<void> {
   const evalResult = evaluatePendingEmptyTrash(pending, Date.now(), window.location.pathname)
   if (!evalResult.shouldRun) return
   if (emptyTrashStopped) return
+  if (isRunOccupied({ engine, runPromise, starting, emptying })) return
 
   emptying = true
   sendStatus('emptyingTrash')

--- a/tests/delete-engine.test.ts
+++ b/tests/delete-engine.test.ts
@@ -167,6 +167,10 @@ class FakeDom implements EngineDom {
   releaseSleep(): void {
     for (const r of this.sleepResolvers.splice(0)) r()
   }
+
+  hasPendingSleep(): boolean {
+    return this.sleepResolvers.length > 0
+  }
 }
 
 const FAST_CONFIG = {
@@ -461,6 +465,61 @@ describe('DeleteEngine — pause holds a dry-run scan (GPDT-CONTROL)', () => {
     const totalAtPause = lastTotal()
     dom.releaseSleep()
     await new Promise((r) => setTimeout(r, 20))
+    expect(lastTotal()).toBe(totalAtPause)
+    expect(lastTotal()).toBe(2)
+
+    engine.resume()
+    const pump = setInterval(() => dom.releaseSleep(), 1)
+    try {
+      const result = await runPromise
+      expect(result.status).toBe('done')
+      expect(result.deleted).toBe(0)
+      expect(result.total).toBe(3)
+      expect(engine.getDryRunLabels()).toContain('Photo - c')
+    } finally {
+      clearInterval(pump)
+    }
+  })
+
+  it('does not harvest newly appeared labels during a scroll-settle poll while paused', async () => {
+    const dom = new FakeDom()
+    dom.manualSleep = true
+    // height > client so findScrollTarget exists and scrollAndHarvest polls.
+    dom.scrollState = { top: 0, height: 1200, client: 800 }
+    dom.setTiles(['Photo - a', 'Photo - b'])
+    const { engine, onProgress } = makeEngine(dom, {
+      maxCount: 500,
+      dryRun: true,
+      pollDelay: 200,
+      scrollSettleMs: 1,
+    })
+    const lastTotal = () => {
+      const calls = onProgress.mock.calls
+      const last = calls[calls.length - 1]?.[0] as { total?: number } | undefined
+      return last?.total ?? 0
+    }
+    const waitFor = async (pred: () => boolean, what: string): Promise<void> => {
+      const start = Date.now()
+      while (!pred()) {
+        if (Date.now() - start > 1000) throw new Error(what)
+        await new Promise((r) => setTimeout(r, 5))
+      }
+    }
+
+    const runPromise = engine.run()
+    await waitFor(() => dom.hasPendingSleep(), 'initial settle sleep never queued')
+    dom.releaseSleep()
+    await waitFor(() => lastTotal() === 2, 'initial harvest never emitted')
+    await waitFor(() => dom.hasPendingSleep(), 'scroll-settle poll sleep never queued')
+
+    engine.pause()
+    expect(engine.isPaused).toBe(true)
+    dom.appendTiles(['Photo - c'])
+    const totalAtPause = lastTotal()
+    dom.releaseSleep()
+    await new Promise((r) => setTimeout(r, 20))
+
+    expect(engine.isPaused).toBe(true)
     expect(lastTotal()).toBe(totalAtPause)
     expect(lastTotal()).toBe(2)
 

--- a/tests/delete-engine.test.ts
+++ b/tests/delete-engine.test.ts
@@ -52,6 +52,10 @@ class FakeDom implements EngineDom {
     })
   }
 
+  appendTiles(labels: string[]): void {
+    for (const label of labels) this.tiles.push(new FakeTile(label))
+  }
+
   selectedCount(): number {
     return this.tiles.filter((t) => t.checked).length
   }
@@ -316,7 +320,7 @@ describe('DeleteEngine — pause / resume', () => {
     engine.pause()
     expect(engine.isPaused).toBe(true)
     dom.releaseSleep()
-    // The loop reaches checkPause() and holds on the pause promise.
+    // The loop reaches awaitControl() and holds on the pause promise.
     await new Promise((r) => setTimeout(r, 5))
     expect(statusesOf(onProgress)).toContain('paused')
 
@@ -334,6 +338,146 @@ describe('DeleteEngine — pause / resume', () => {
     }
   })
 })
+
+
+describe('DeleteEngine — pause holds selection progress (GPDT-CONTROL)', () => {
+  const tileClicks = (dom: FakeDom) => dom.clicks.filter((c) => c.startsWith('tile:'))
+
+  it('pause during a selection wave does not click newly appeared tiles; resume continues the same engine to done', async () => {
+    const dom = new FakeDom()
+    dom.manualSleep = true
+    // No scroll target: this test is about selection waves, not scroll.
+    dom.scrollState = { top: 0, height: 100, client: 800 }
+    dom.setTiles(['Photo - a', 'Photo - b'])
+    const { engine } = makeEngine(dom, {
+      maxCount: 10,
+      selectionSettleMs: 60_000,
+      scrollSettleMs: 60_000,
+      actionTimeout: 60_000,
+    })
+
+    const runPromise = engine.run()
+    await new Promise((r) => setTimeout(r, 10))
+    expect(tileClicks(dom)).toEqual(['tile:Photo - a', 'tile:Photo - b'])
+
+    engine.pause()
+    expect(engine.isPaused).toBe(true)
+    dom.appendTiles(['Photo - c', 'Photo - d'])
+    const clicksAtPause = tileClicks(dom).length
+    dom.releaseSleep()
+    await new Promise((r) => setTimeout(r, 20))
+
+    expect(engine.isPaused).toBe(true)
+    expect(tileClicks(dom)).toHaveLength(clicksAtPause)
+    expect(dom.clicks).not.toContain('tile:Photo - c')
+    expect(dom.clicks).not.toContain('tile:Photo - d')
+    expect(dom.clicks.filter((c) => c === 'confirm')).toHaveLength(0)
+
+    engine.resume()
+    expect(engine.isPaused).toBe(false)
+    const pump = setInterval(() => dom.releaseSleep(), 1)
+    try {
+      const result = await runPromise
+      expect(result.status).toBe('done')
+      expect(result.deleted).toBe(4)
+      expect(dom.clicks).toContain('tile:Photo - c')
+      expect(dom.clicks).toContain('tile:Photo - d')
+    } finally {
+      clearInterval(pump)
+    }
+  })
+
+  it('pause during a delete wait does not burn the action timeout', async () => {
+    const dom = new FakeDom()
+    dom.manualSleep = true
+    dom.scrollState = { top: 0, height: 100, client: 800 }
+    dom.setTiles(['Photo - a'])
+    // Confirm never appears — waitFor(confirm) holds.
+    dom.dialogHasConfirm = false
+    const { engine } = makeEngine(dom, { maxCount: 1, actionTimeout: 40, pollDelay: 10 })
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const runPromise = engine.run()
+    const advance = setInterval(() => {
+      if (!engine.isPaused && !engine.isStopped) dom.releaseSleep()
+    }, 1)
+    const startWait = Date.now()
+    while (!dom.clicks.includes('delete')) {
+      if (Date.now() - startWait > 1000) {
+        clearInterval(advance)
+        throw new Error('never reached delete click')
+      }
+      await new Promise((r) => setTimeout(r, 5))
+    }
+    clearInterval(advance)
+
+    engine.pause()
+    expect(engine.isPaused).toBe(true)
+    dom.releaseSleep()
+    await new Promise((r) => setTimeout(r, 10))
+    // Wall-clock longer than actionTimeout; pause must hold, not error.
+    await new Promise((r) => setTimeout(r, 80))
+    expect(engine.isPaused).toBe(true)
+
+    let settled: { status: string; error?: string } | null = null
+    void runPromise.then((r) => { settled = r })
+    await new Promise((r) => setTimeout(r, 10))
+    expect(settled).toBeNull()
+
+    engine.stop()
+    dom.releaseSleep()
+    const result = await runPromise
+    expect(result.status).toBe('idle')
+    expect(result.error).toBeUndefined()
+    errorSpy.mockRestore()
+  })
+})
+
+describe('DeleteEngine — pause holds a dry-run scan (GPDT-CONTROL)', () => {
+  it('does not harvest newly appeared labels while paused; resume continues the same scan', async () => {
+    const dom = new FakeDom()
+    dom.manualSleep = true
+    dom.scrollState = { top: 0, height: 100, client: 800 }
+    dom.setTiles(['Photo - a', 'Photo - b'])
+    const { engine, onProgress } = makeEngine(dom, {
+      maxCount: 500,
+      dryRun: true,
+      pollDelay: 200,
+      scrollSettleMs: 60_000,
+      selectionSettleMs: 60_000,
+    })
+    const lastTotal = () => {
+      const calls = onProgress.mock.calls
+      const last = calls[calls.length - 1]?.[0] as { total?: number } | undefined
+      return last?.total ?? 0
+    }
+
+    const runPromise = engine.run()
+    await new Promise((r) => setTimeout(r, 10))
+    expect(lastTotal()).toBe(2)
+    engine.pause()
+    expect(engine.isPaused).toBe(true)
+    dom.appendTiles(['Photo - c'])
+    const totalAtPause = lastTotal()
+    dom.releaseSleep()
+    await new Promise((r) => setTimeout(r, 20))
+    expect(lastTotal()).toBe(totalAtPause)
+    expect(lastTotal()).toBe(2)
+
+    engine.resume()
+    const pump = setInterval(() => dom.releaseSleep(), 1)
+    try {
+      const result = await runPromise
+      expect(result.status).toBe('done')
+      expect(result.deleted).toBe(0)
+      expect(result.total).toBe(3)
+      expect(engine.getDryRunLabels()).toContain('Photo - c')
+    } finally {
+      clearInterval(pump)
+    }
+  })
+})
+
 
 describe('DeleteEngine — checkbox flap & counter fallback', () => {
   it('records a flap recovery when the counter regresses, and still completes', async () => {

--- a/tests/empty-trash.test.ts
+++ b/tests/empty-trash.test.ts
@@ -5,6 +5,7 @@ import {
   type EmptyTrashDeps,
   type EmptyTrashStatus,
 } from '../src/core/empty-trash'
+import { StopRequested } from '../src/core/run-occupancy'
 
 /**
  * The flow's job is orchestration: find → click → find dialog → find
@@ -239,5 +240,53 @@ describe('runEmptyTrashFlow — logging', () => {
   it('works without log / onStatus (no-ops by default)', async () => {
     const { deps } = happyWorld()
     await expect(runEmptyTrashFlow({ ...deps, log: undefined, onStatus: undefined })).resolves.toBeUndefined()
+  })
+})
+
+describe('runEmptyTrashFlow — user stop (GPDT-CONTROL)', () => {
+  it('rethrows StopRequested without reporting error or clicking', async () => {
+    const empty = fakeButton('Empty trash')
+    const statuses: EmptyTrashStatus[] = []
+    const deps: EmptyTrashDeps = {
+      findEmptyTrashButton: () => empty as unknown as HTMLElement,
+      findConfirmDialog: () => null,
+      findConfirmButton: () => null,
+      isTrashEmpty: () => false,
+      waitFor: async () => { throw new StopRequested() },
+      sleep: vi.fn().mockResolvedValue(undefined),
+      onStatus: (status) => statuses.push(status),
+    }
+    await expect(runEmptyTrashFlow(deps)).rejects.toBeInstanceOf(StopRequested)
+    expect(empty.click).not.toHaveBeenCalled()
+    expect(statuses).toEqual(['emptyingTrash'])
+  })
+
+  it('stop after confirm does not report done or error', async () => {
+    const empty = fakeButton('Empty trash')
+    const dialog = fakeDialog()
+    const confirm = fakeButton('Move to trash')
+    const statuses: EmptyTrashStatus[] = []
+    let step = 0
+    const deps: EmptyTrashDeps = {
+      findEmptyTrashButton: () => empty as unknown as HTMLElement,
+      findConfirmDialog: () => dialog as unknown as HTMLElement,
+      findConfirmButton: () => confirm as unknown as HTMLElement,
+      isTrashEmpty: () => false,
+      waitFor: async (cond) => {
+        step += 1
+        if (step <= 3) {
+          const v = cond()
+          if (!v) throw new Error('Timed out')
+          return v as NonNullable<typeof v>
+        }
+        throw new StopRequested()
+      },
+      sleep: vi.fn().mockResolvedValue(undefined),
+      onStatus: (status) => statuses.push(status),
+    }
+    await expect(runEmptyTrashFlow(deps)).rejects.toBeInstanceOf(StopRequested)
+    expect(empty.click).toHaveBeenCalledTimes(1)
+    expect(confirm.click).toHaveBeenCalledTimes(1)
+    expect(statuses).toEqual(['emptyingTrash'])
   })
 })

--- a/tests/page-runner.test.ts
+++ b/tests/page-runner.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { PageRunner, ConsentRequiredError, PermanentActionRequiredError } from '../src/core/page-runner'
+import { PageRunner, ConsentRequiredError, PermanentActionRequiredError, RunInProgressError } from '../src/core/page-runner'
+import { runEmptyTrashFlow } from '../src/core/empty-trash'
 import type { EngineDom, ClickTarget, PhotoTile, ScrollTarget } from '../src/core/dom-adapter'
 import { TRASH_URL, type EmptyTrashBaton } from '../src/core/empty-trash-baton'
 import { CONSENT_KEY, EMPTY_TRASH_ACK_KEY } from '../src/core/consent'
@@ -18,6 +19,7 @@ class RunnerFakeDom implements EngineDom {
   clicks: string[] = []
   holdSleep = false
   private sleepResolvers: Array<() => void> = []
+  sleepGate: Promise<void> | null = null
 
   setTiles(labels: string[]): void {
     this.tiles = labels.map((label) => ({ label, checked: false }))
@@ -45,6 +47,7 @@ class RunnerFakeDom implements EngineDom {
   findScrollTarget(): ScrollTarget | null { return null }
   click(target: ClickTarget): void { target.click() }
   async sleep(): Promise<void> {
+    if (this.sleepGate) await this.sleepGate
     if (!this.holdSleep) return
     await new Promise<void>((resolve) => { this.sleepResolvers.push(resolve) })
   }
@@ -178,7 +181,7 @@ describe('PageRunner — occupancy', () => {
     const first = runner.start({ maxCount: 500, dryRun: false, emptyTrashAfter: false, filter: { kind: 'all' } })
     expect(runner.getStatus().running).toBe(true)
     const second = runner.start({ maxCount: 500, dryRun: false, emptyTrashAfter: false, filter: { kind: 'all' } })
-    await expect(second).resolves.toBeUndefined()
+    await expect(second).rejects.toBeInstanceOf(RunInProgressError)
     expect(runner.getStatus().running).toBe(true)
 
     dom.releaseSleep()
@@ -333,5 +336,117 @@ describe('PageRunner — issue report URL', () => {
     const decoded = decodeURIComponent(url).replace(/\+/g, ' ')
     expect(decoded).toContain('[drift] Tool stopped working correctly')
     expect(decoded).toContain('Diagnostic data')
+  })
+})
+
+describe('PageRunner — second start refused while a run occupies the slot (GPDT-CONTROL)', () => {
+  it('throws RunInProgressError on a second start while the first run is settling and does not confirm twice', async () => {
+    stubWindow()
+    const dom = new RunnerFakeDom()
+    dom.setTiles(['Photo - a'])
+    let release: () => void = () => undefined
+    dom.sleepGate = new Promise<void>((r) => { release = r })
+    const runner = new PageRunner({ dom: dom as unknown as EngineDom, baton: fakeBaton() })
+    runner.acknowledgeConsent()
+
+    const first = runner.start({ maxCount: 500, dryRun: false, emptyTrashAfter: false, filter: { kind: 'all' } })
+    const startWait = Date.now()
+    while (!runner.getStatus().running) {
+      if (Date.now() - startWait > 1000) throw new Error('first start never occupied the slot')
+      await new Promise((r) => setTimeout(r, 5))
+    }
+
+    await expect(
+      runner.start({ maxCount: 500, dryRun: true, emptyTrashAfter: false, filter: { kind: 'all' } }),
+    ).rejects.toBeInstanceOf(RunInProgressError)
+    expect(dom.clicks.filter((c) => c === 'confirm')).toHaveLength(0)
+
+    release()
+    await first
+    expect(dom.clicks.filter((c) => c === 'confirm')).toHaveLength(1)
+    expect(runner.getStatus().running).toBe(false)
+  })
+})
+
+describe('PageRunner — empty-trash occupancy and stop (GPDT-CONTROL)', () => {
+  const pendingBaton = () => {
+    const baton = fakeBaton()
+    void baton.writePending()
+    return baton
+  }
+
+  it('refuses a second start while empty-trash occupies the run slot', async () => {
+    stubWindow()
+    const dom = new RunnerFakeDom()
+    dom.pathname = '/trash'
+    let release: () => void = () => undefined
+    const hang = new Promise<void>((r) => { release = r })
+    let emptyStarts = 0
+    const runner = new PageRunner({
+      dom: dom as unknown as EngineDom,
+      baton: pendingBaton(),
+      runEmptyTrash: async ({ onStatus }) => {
+        emptyStarts += 1
+        onStatus?.('emptyingTrash')
+        await hang
+        onStatus?.('done')
+      },
+    })
+
+    const emptying = runner.maybeRunPendingEmptyTrash()
+    const startWait = Date.now()
+    while (!runner.getStatus().running) {
+      if (Date.now() - startWait > 1000) throw new Error('empty-trash never occupied the slot')
+      await new Promise((r) => setTimeout(r, 5))
+    }
+    expect(runner.getStatus().progress?.status).toBe('emptyingTrash')
+
+    await expect(
+      runner.start({ maxCount: 500, dryRun: true, emptyTrashAfter: false, filter: { kind: 'all' } }),
+    ).rejects.toBeInstanceOf(RunInProgressError)
+    expect(emptyStarts).toBe(1)
+
+    release()
+    await emptying
+    expect(emptyStarts).toBe(1)
+    expect(runner.getStatus().running).toBe(false)
+  })
+
+  it('stop during an empty-trash wait resolves to idle, never done or error, and does not click confirm', async () => {
+    stubWindow()
+    const dom = new RunnerFakeDom()
+    dom.pathname = '/trash'
+    const statuses: string[] = []
+    const runner = new PageRunner({
+      dom: dom as unknown as EngineDom,
+      baton: pendingBaton(),
+      runEmptyTrash: (deps) => runEmptyTrashFlow({
+        findEmptyTrashButton: () => null,
+        findConfirmDialog: () => null,
+        findConfirmButton: () => null,
+        isTrashEmpty: () => false,
+        ...deps,
+      }),
+    })
+    const unsub = runner.onUpdate((s) => {
+      if (s.progress) statuses.push(s.progress.status)
+    })
+
+    const emptying = runner.maybeRunPendingEmptyTrash()
+    const startWait = Date.now()
+    while (!runner.getStatus().running) {
+      if (Date.now() - startWait > 1000) throw new Error('empty-trash never occupied the slot')
+      await new Promise((r) => setTimeout(r, 5))
+    }
+
+    runner.stop()
+    await emptying
+    unsub()
+
+    expect(runner.getStatus().running).toBe(false)
+    expect(runner.getStatus().progress?.status).toBe('idle')
+    expect(runner.getStatus().progress?.error).toBeUndefined()
+    expect(statuses).not.toContain('done')
+    expect(statuses).not.toContain('error')
   })
 })

--- a/tests/page-runner.test.ts
+++ b/tests/page-runner.test.ts
@@ -450,3 +450,54 @@ describe('PageRunner — empty-trash occupancy and stop (GPDT-CONTROL)', () => {
     expect(statuses).not.toContain('error')
   })
 })
+
+describe('PageRunner — empty-trash admission cannot race a live start (GPDT-CONTROL)', () => {
+  it('does not start empty-trash if a start occupied the slot during baton I/O, and does not release the live start', async () => {
+    stubWindow()
+    const dom = new RunnerFakeDom()
+    dom.pathname = '/trash'
+    dom.setTiles(['Photo - a'])
+    let releaseBaton: () => void = () => undefined
+    const batonHold = new Promise<void>((r) => { releaseBaton = r })
+    const baton = fakeBaton()
+    void baton.writePending()
+    const origRead = baton.readPending.bind(baton)
+    baton.readPending = async () => {
+      await batonHold
+      return origRead()
+    }
+    let emptyStarts = 0
+    const runner = new PageRunner({
+      dom: dom as unknown as EngineDom,
+      baton,
+      runEmptyTrash: async () => { emptyStarts += 1 },
+    })
+    runner.acknowledgeConsent()
+    let releaseSleep: () => void = () => undefined
+    dom.sleepGate = new Promise<void>((r) => { releaseSleep = r })
+
+    const emptying = runner.maybeRunPendingEmptyTrash()
+    const first = runner.start({ maxCount: 500, dryRun: false, emptyTrashAfter: false, filter: { kind: 'all' } })
+    const startWait = Date.now()
+    while (!runner.getStatus().running) {
+      if (Date.now() - startWait > 1000) throw new Error('start never occupied the slot')
+      await new Promise((r) => setTimeout(r, 5))
+    }
+
+    releaseBaton()
+    await new Promise((r) => setTimeout(r, 20))
+    expect(emptyStarts).toBe(0)
+    expect(runner.getStatus().running).toBe(true)
+
+    await expect(
+      runner.start({ maxCount: 500, dryRun: true, emptyTrashAfter: false, filter: { kind: 'all' } }),
+    ).rejects.toBeInstanceOf(RunInProgressError)
+
+    releaseSleep()
+    await first
+    await emptying
+    expect(emptyStarts).toBe(0)
+    expect(dom.clicks.filter((c) => c === 'confirm')).toHaveLength(1)
+    expect(runner.getStatus().running).toBe(false)
+  })
+})

--- a/tests/run-occupancy.test.ts
+++ b/tests/run-occupancy.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import {
+  isRunOccupied,
+  RunInProgressError,
+  RUN_IN_PROGRESS_MESSAGE,
+  StopRequested,
+  waitUntilAbortable,
+} from '../src/core/run-occupancy'
+
+describe('isRunOccupied', () => {
+  it('is free when no slot is taken', () => {
+    expect(isRunOccupied({})).toBe(false)
+    expect(isRunOccupied({ engine: null, runPromise: null, starting: false, emptying: false })).toBe(false)
+  })
+
+  it('is occupied by an engine, settling tail, start handshake, or empty-trash', () => {
+    expect(isRunOccupied({ engine: {} })).toBe(true)
+    expect(isRunOccupied({ runPromise: Promise.resolve() })).toBe(true)
+    expect(isRunOccupied({ starting: true })).toBe(true)
+    expect(isRunOccupied({ emptying: true })).toBe(true)
+    expect(isRunOccupied({ running: true })).toBe(true)
+  })
+})
+
+describe('RunInProgressError', () => {
+  it('carries the shared refusal message', () => {
+    const err = new RunInProgressError()
+    expect(err.name).toBe('RunInProgressError')
+    expect(err.message).toBe(RUN_IN_PROGRESS_MESSAGE)
+    expect(err.message).toMatch(/already in progress/)
+  })
+})
+
+describe('waitUntilAbortable', () => {
+  it('returns when the condition becomes truthy', async () => {
+    let n = 0
+    const result = await waitUntilAbortable(
+      () => {
+        n++
+        return n >= 3 ? 'ok' : null
+      },
+      1000,
+      1,
+      () => false,
+      async () => undefined,
+    )
+    expect(result).toBe('ok')
+  })
+
+  it('throws StopRequested as soon as the stop flag is set, not a timeout error', async () => {
+    let stopped = false
+    const pending = waitUntilAbortable(
+      () => null,
+      10_000,
+      5,
+      () => stopped,
+      () => new Promise((r) => setTimeout(r, 5)),
+    )
+    await new Promise((r) => setTimeout(r, 15))
+    stopped = true
+    await expect(pending).rejects.toBeInstanceOf(StopRequested)
+  })
+
+  it('times out when the condition never becomes truthy and nobody stops', async () => {
+    await expect(
+      waitUntilAbortable(() => null, 3, 1, () => false, async () => undefined),
+    ).rejects.toThrow(/Timed out after 3ms/)
+  })
+})


### PR DESCRIPTION
## Identity

- **identity:** `GPDT-CONTROL` — Keep a run under present user control
- **fate:** `live` (as declared in dest)
- **destination revision:** `9e0007d1acca3a4d860c8e8ee54be1cde77ba786` (`docs/vision.md` + `docs/capabilities.md`; GPDT-CONSENT #18 is on master. This PR does not edit dest docs.)
- **candidate_sha:** `48a2315cb6e8669efeb962dd3890be7d220432a8`

Ready is this exact SHA, not Done. A head move voids review.

## Write/effect set (source only)

Pause holds progress, resume continues the same engine, stop interrupts action waits and resolves to idle, and a supported surface cannot start a second engine while the first run is settling.

#18 consent remains the sole writer for `admitDestructiveRun`, `shouldNavigateToEmptyTrash`, `admitConcurrentStart`, and `RUN_IN_PROGRESS_ERROR`. This PR does not restore page-runner/content if-ladders for those admissions.

Files (this PR vs `9e0007d1`):

- `src/core/run-occupancy.ts` — **new**: shared `StopRequested`, `RunInProgressError` / `RUN_IN_PROGRESS_MESSAGE`, `isRunOccupied`, and abort-aware `waitUntilAbortable` (remaining-budget timeout; stop throws `StopRequested` rather than a timeout error).
- `src/core/delete-engine.ts` — selection waves, scroll settle, dry-run harvest/settle, and `waitFor` yield to pause/stop via `awaitControl()` / `sleepControlled()`. Pause holds remaining settle/timeout budgets instead of wall-clock `Date.now()`. Control is re-checked after in-flight sleeps so a pause does not harvest newly appeared dry-run labels. A user stop during the dry-run's initial top-of-gallery settle is caught so the scan resolves `idle`, never a rejected promise.
- `src/core/empty-trash.ts` — rethrow `StopRequested` from every catch so a user stop is not converted into empty-trash `error` or a false `done`.
- `src/core/page-runner.ts` — second `start()` while `running` throws `RunInProgressError`; empty-trash occupies `running` and uses abort-aware waits; `stop()` interrupts empty-trash; host maps `StopRequested` to progress `idle`, never empty-trash `error`/`done`. Empty-trash baton is cleared on first sight; occupancy is re-checked after baton I/O so a live start is not released in `finally`.
- `src/extension/content.ts` — occupancy includes engine, settling `runPromise`, start handshake, and emptying; `isRunning()` is true while emptying; empty-trash waits are abort-aware; Stop maps to `idle`; a refused concurrent start returns `{ ok: false, error: RUN_IN_PROGRESS_ERROR }`.
- `src/core/index.ts` — export occupancy symbols.
- Tests: `tests/run-occupancy.test.ts`, `tests/delete-engine.test.ts`, `tests/page-runner.test.ts`, `tests/empty-trash.test.ts`.

Does not edit `docs/vision.md` or `docs/capabilities.md`. Does not take GPDT-EVIDENCE, GPDT-BATCH-VERIFY, GPDT-OBSERVE `findScrollTarget` fallback, GPDT-TRASH-HANDOFF baton-write tests, store revival, or a version bump. No live deletions; no store/release effect.

## Done-when (oracle, named at dest)

From `docs/capabilities.md` at `9e0007d1`:

> Pause holds progress, resume continues the same engine, stop interrupts action waits and resolves to idle, and a supported surface cannot start a second engine while the first run is settling.

Named at source:

1. **Pause holds progress.** A pause during a selection wave does not click newly appeared tiles; a pause during a delete wait does not burn `actionTimeout`; a pause during a dry-run scan does not harvest newly appeared labels (including after an in-flight scroll-settle sleep). Resume continues the same engine to `done`.
2. **Stop interrupts action waits and resolves to idle.** Stop during a delete wait, during a dry-run settle, and during an empty-trash wait resolves `idle` with no `error`. Empty-trash stop is never mapped to empty-trash `error` or `done`.
3. **One run slot.** A second `start` while the first run is settling throws `RunInProgressError` (page-runner) or returns `RUN_IN_PROGRESS_ERROR` (content) and does not confirm twice. Empty-trash occupies the slot: a second `start` while emptying is refused, empty-trash is not started twice, and empty-trash admission that races a live start across baton I/O does not occupy-then-release that start.

## Evidence layer

Source / local tests + forge check on this SHA. Not landed, not live-browser, not store.

Working tree clean at `candidate_sha` `48a2315cb6e8669efeb962dd3890be7d220432a8`:

- `bun run typecheck` — pass
- `bun run lint` — pass
- `bun run test` — 251 passed (19 files)

Forge check on the same SHA (not a land):

- GitHub Actions run [33972146915](https://github.com/shtse8/Google-Photos-Delete-Tool/actions/runs/33972146915) — `Lint, Type Check, Test, Build & Verify` success (`head_sha=48a2315cb6e8669efeb962dd3890be7d220432a8`)
- Tests in that run: 251 passed (19 files); `bun run verify` reported all artifacts consistent

No live Google Photos session; no destructive action was performed.

## Recovery

Revert this PR / drop this branch. No data migration, no live writer, no store publish. Pause/stop/occupancy are control-plane behaviour on an already-admitted run; they do not change consent, batch limits, or empty-trash postcondition proof.

## Next action

A different session than the SHA author reviews this exact SHA independently (high-harm: deletion). Do not merge until that review Accepts `48a2315cb6e8669efeb962dd3890be7d220432a8`. Ready is not Done. A head move voids the review.

- base: `master@9e0007d1acca3a4d860c8e8ee54be1cde77ba786`
- mergeable: CLEAN / MERGEABLE vs that base
- prior dirty head `454e8ea5` is void
