### PR TITLE
feat(core): sole writer for consent, empty-trash chain, and occupancy

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -60,18 +60,23 @@ flowchart TD
 
 ## Repository evidence
 
+- `GPDT-ENTER`: [surface.ts](../src/core/surface.ts) and
+  [surface.test.ts](../tests/surface.test.ts)
 - `GPDT-OBSERVE`: [selector-pack.ts](../src/core/selector-pack.ts),
   [selectors.ts](../src/core/selectors.ts), and
   [selectors.test.ts](../tests/selectors.test.ts)
 - `GPDT-PREVIEW`, `GPDT-BATCH`, `GPDT-BATCH-VERIFY`, and `GPDT-CONTROL`:
   [delete-engine.ts](../src/core/delete-engine.ts),
-  [config.ts](../src/core/config.ts), and
-  [delete-engine.test.ts](../tests/delete-engine.test.ts)
-- `GPDT-CONSENT`: [page-runner.ts](../src/core/page-runner.ts),
-  [content.ts](../src/extension/content.ts), and
-  [ui-wiring.test.ts](../tests/ui-wiring.test.ts)
-- `GPDT-TRASH-HANDOFF`: [empty-trash-baton.ts](../src/core/empty-trash-baton.ts)
-  and [empty-trash-baton.test.ts](../tests/empty-trash-baton.test.ts)
+  [config.ts](../src/core/config.ts),
+  [delete-engine.test.ts](../tests/delete-engine.test.ts), and
+  [page-runner.test.ts](../tests/page-runner.test.ts)
+- `GPDT-CONSENT`: [consent.ts](../src/core/consent.ts),
+  [consent.test.ts](../tests/consent.test.ts),
+  [page-runner.ts](../src/core/page-runner.ts), and
+  [content.ts](../src/extension/content.ts)
+- `GPDT-TRASH-HANDOFF`: [empty-trash-baton.ts](../src/core/empty-trash-baton.ts),
+  [empty-trash-baton.test.ts](../tests/empty-trash-baton.test.ts), and
+  [consent.ts](../src/core/consent.ts)
 - `GPDT-EMPTY-VERIFY`: [empty-trash.ts](../src/core/empty-trash.ts) and
   [empty-trash.test.ts](../tests/empty-trash.test.ts)
 - `GPDT-EVIDENCE`: [RELEASE_GATE.md](RELEASE_GATE.md)

--- a/src/core/consent.ts
+++ b/src/core/consent.ts
@@ -1,0 +1,146 @@
+/**
+ * Sole writer for destructive-run admission, empty-trash chain
+ * admission, and single-run occupancy.
+ *
+ * Identities: GPDT-CONSENT, GPDT-TRASH-HANDOFF (chain predicate),
+ * GPDT-CONTROL (no second engine while the first is settling).
+ *
+ * Surfaces read their own storage backends and pass interpreted
+ * acknowledgements here. This module does not know chrome.storage vs
+ * localStorage; it only admits or refuses.
+ */
+import type { RunStatus } from './status'
+
+export const CONSENT_KEY = 'gpdt_consent_v3'
+export const EMPTY_TRASH_ACK_KEY = 'gpdt_emptyTrashAck_v3'
+
+/** Userscript / panel localStorage acknowledgement token. */
+export const LOCAL_ACK_VALUE = '1'
+
+export type Acknowledgement = {
+  readable: boolean
+  acknowledged: boolean
+}
+
+export type DestructiveRefuseReason =
+  | 'consent-missing'
+  | 'consent-unreadable'
+  | 'empty-trash-ack-missing'
+  | 'empty-trash-ack-unreadable'
+
+export type DestructiveAdmission =
+  | { ok: true }
+  | { ok: false; reason: DestructiveRefuseReason }
+
+export type OccupancyAdmission =
+  | { ok: true }
+  | { ok: false; reason: 'run-in-progress' }
+
+export class ConsentRequiredError extends Error {
+  constructor() {
+    super('consent required before a destructive run')
+    this.name = 'ConsentRequiredError'
+  }
+}
+
+export class PermanentActionRequiredError extends Error {
+  constructor() {
+    super('permanent empty-trash acknowledgement required before an empty-trash run')
+    this.name = 'PermanentActionRequiredError'
+  }
+}
+
+/** Public extension IPC error tokens for a refused destructive start. */
+export const EXTENSION_ADMISSION_ERROR: Record<DestructiveRefuseReason, string> = {
+  'consent-missing':
+    'Consent required — confirm the safety notice in the popup first.',
+  'consent-unreadable': 'Could not read consent state.',
+  'empty-trash-ack-missing':
+    'Permanent empty-trash consent required — confirm the permanent-action warning in the popup first.',
+  'empty-trash-ack-unreadable':
+    'Could not read permanent empty-trash consent state.',
+}
+
+export const RUN_IN_PROGRESS_ERROR = 'A run is already in progress — stop it first.'
+
+export function admitDestructiveRun(input: {
+  dryRun: boolean
+  emptyTrashAfter: boolean
+  consent: Acknowledgement
+  emptyTrashAck: Acknowledgement
+}): DestructiveAdmission {
+  if (input.dryRun) return { ok: true }
+
+  if (!input.consent.readable) {
+    return { ok: false, reason: 'consent-unreadable' }
+  }
+  if (!input.consent.acknowledged) {
+    return { ok: false, reason: 'consent-missing' }
+  }
+
+  if (input.emptyTrashAfter) {
+    if (!input.emptyTrashAck.readable) {
+      return { ok: false, reason: 'empty-trash-ack-unreadable' }
+    }
+    if (!input.emptyTrashAck.acknowledged) {
+      return { ok: false, reason: 'empty-trash-ack-missing' }
+    }
+  }
+
+  return { ok: true }
+}
+
+/**
+ * Empty-trash navigation is admitted only after a clean real run that
+ * deleted at least one item. A dry-run, a stop, a zero-delete finish,
+ * or a non-done status must not chain.
+ */
+export function shouldNavigateToEmptyTrash(input: {
+  dryRun: boolean
+  emptyTrashAfter: boolean
+  stopped: boolean
+  status: RunStatus
+  deleted: number
+}): boolean {
+  return (
+    !input.dryRun &&
+    input.emptyTrashAfter &&
+    !input.stopped &&
+    input.status === 'done' &&
+    input.deleted > 0
+  )
+}
+
+export function admitConcurrentStart(occupied: boolean): OccupancyAdmission {
+  return occupied ? { ok: false, reason: 'run-in-progress' } : { ok: true }
+}
+
+export function readLocalAcknowledgement(key: string): Acknowledgement {
+  try {
+    return {
+      readable: true,
+      acknowledged: window.localStorage.getItem(key) === LOCAL_ACK_VALUE,
+    }
+  } catch {
+    return { readable: false, acknowledged: false }
+  }
+}
+
+export function writeLocalAcknowledgement(key: string): void {
+  try {
+    window.localStorage.setItem(key, LOCAL_ACK_VALUE)
+  } catch {
+    /* storage unavailable — acknowledgement re-asked next start */
+  }
+}
+
+export function throwForDestructiveRefusal(reason: DestructiveRefuseReason): never {
+  switch (reason) {
+    case 'consent-missing':
+    case 'consent-unreadable':
+      throw new ConsentRequiredError()
+    case 'empty-trash-ack-missing':
+    case 'empty-trash-ack-unreadable':
+      throw new PermanentActionRequiredError()
+  }
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -81,3 +81,23 @@ export {
   type PhotosViewKind,
   type SurfaceAdmission,
 } from './surface'
+
+export {
+  CONSENT_KEY,
+  EMPTY_TRASH_ACK_KEY,
+  LOCAL_ACK_VALUE,
+  EXTENSION_ADMISSION_ERROR,
+  RUN_IN_PROGRESS_ERROR,
+  admitDestructiveRun,
+  shouldNavigateToEmptyTrash,
+  admitConcurrentStart,
+  readLocalAcknowledgement,
+  writeLocalAcknowledgement,
+  throwForDestructiveRefusal,
+  ConsentRequiredError,
+  PermanentActionRequiredError,
+  type Acknowledgement,
+  type DestructiveAdmission,
+  type DestructiveRefuseReason,
+  type OccupancyAdmission,
+} from './consent'

--- a/src/core/page-runner.ts
+++ b/src/core/page-runner.ts
@@ -17,6 +17,18 @@ import { buildDiagnosticIssueUrl, diagnostics } from './diagnostics'
 import { verifyLicense } from './license'
 import { classifyLabel, type PhotoFilter, type PhotoType } from './photo-filter'
 import type { RunStatus } from './status'
+import {
+  CONSENT_KEY,
+  EMPTY_TRASH_ACK_KEY,
+  admitConcurrentStart,
+  admitDestructiveRun,
+  readLocalAcknowledgement,
+  shouldNavigateToEmptyTrash,
+  throwForDestructiveRefusal,
+  writeLocalAcknowledgement,
+} from './consent'
+
+export { ConsentRequiredError, PermanentActionRequiredError } from './consent'
 
 export interface PanelRunOptions {
   maxCount: number
@@ -37,23 +49,7 @@ export interface DryRunSummary {
   counts: Record<PhotoType, number>
 }
 
-const CONSENT_KEY = 'gpdt_consent_v3'
-const EMPTY_TRASH_ACK_KEY = 'gpdt_emptyTrashAck_v3'
 const LICENSE_KEY = 'gpdt_pro_token_v3'
-
-export class ConsentRequiredError extends Error {
-  constructor() {
-    super('consent required before a destructive run')
-    this.name = 'ConsentRequiredError'
-  }
-}
-
-export class PermanentActionRequiredError extends Error {
-  constructor() {
-    super('permanent empty-trash acknowledgement required before an empty-trash run')
-    this.name = 'PermanentActionRequiredError'
-  }
-}
 
 export class PageRunner {
   private engine: DeleteEngine | null = null
@@ -99,19 +95,12 @@ export class PageRunner {
   // ─── Consent ──────────────────────────────────────────────────
 
   consentAcknowledged(): boolean {
-    try {
-      return window.localStorage.getItem(CONSENT_KEY) === '1'
-    } catch {
-      return false
-    }
+    const ack = readLocalAcknowledgement(CONSENT_KEY)
+    return ack.readable && ack.acknowledged
   }
 
   acknowledgeConsent(): void {
-    try {
-      window.localStorage.setItem(CONSENT_KEY, '1')
-    } catch {
-      /* storage unavailable — consent re-asked next time */
-    }
+    writeLocalAcknowledgement(CONSENT_KEY)
   }
 
   /**
@@ -122,19 +111,12 @@ export class PageRunner {
    * chains into the permanent empty-trash flow.
    */
   emptyTrashAcknowledged(): boolean {
-    try {
-      return window.localStorage.getItem(EMPTY_TRASH_ACK_KEY) === '1'
-    } catch {
-      return false
-    }
+    const ack = readLocalAcknowledgement(EMPTY_TRASH_ACK_KEY)
+    return ack.readable && ack.acknowledged
   }
 
   acknowledgeEmptyTrash(): void {
-    try {
-      window.localStorage.setItem(EMPTY_TRASH_ACK_KEY, '1')
-    } catch {
-      /* storage unavailable — acknowledgement re-asked next time */
-    }
+    writeLocalAcknowledgement(EMPTY_TRASH_ACK_KEY)
   }
 
   // ─── Pro license ──────────────────────────────────────────────
@@ -176,11 +158,14 @@ export class PageRunner {
   // ─── Run lifecycle ────────────────────────────────────────────
 
   async start(opts: PanelRunOptions): Promise<void> {
-    if (this.running) return
-    if (!opts.dryRun) {
-      if (!this.consentAcknowledged()) throw new ConsentRequiredError()
-      if (opts.emptyTrashAfter && !this.emptyTrashAcknowledged()) throw new PermanentActionRequiredError()
-    }
+    if (!admitConcurrentStart(this.running).ok) return
+    const admission = admitDestructiveRun({
+      dryRun: opts.dryRun,
+      emptyTrashAfter: opts.emptyTrashAfter,
+      consent: readLocalAcknowledgement(CONSENT_KEY),
+      emptyTrashAck: readLocalAcknowledgement(EMPTY_TRASH_ACK_KEY),
+    })
+    if (!admission.ok) throwForDestructiveRefusal(admission.reason)
     this.running = true
     this.summary = null
     this.progress = null
@@ -204,13 +189,13 @@ export class PageRunner {
       }
 
       // Empty-trash chain: only after a clean, real run that deleted ≥1.
-      if (
-        !opts.dryRun &&
-        opts.emptyTrashAfter &&
-        !engine.isStopped &&
-        result.status === 'done' &&
-        result.deleted > 0
-      ) {
+      if (shouldNavigateToEmptyTrash({
+        dryRun: opts.dryRun,
+        emptyTrashAfter: opts.emptyTrashAfter,
+        stopped: engine.isStopped,
+        status: result.status,
+        deleted: result.deleted,
+      })) {
         const ok = await this.baton.writePending()
         if (ok) {
           this.setProgress({

--- a/src/extension/content.ts
+++ b/src/extension/content.ts
@@ -26,6 +26,16 @@ import { evaluatePendingEmptyTrash, TRASH_URL } from '../core/empty-trash-baton'
 import { runEmptyTrashFlow, type EmptyTrashStatus } from '../core/empty-trash'
 import type { RunStatus } from '../core/status'
 import { isSupportedPhotosUrl } from '../core/surface'
+import {
+  CONSENT_KEY,
+  EMPTY_TRASH_ACK_KEY,
+  EXTENSION_ADMISSION_ERROR,
+  RUN_IN_PROGRESS_ERROR,
+  admitConcurrentStart,
+  admitDestructiveRun,
+  shouldNavigateToEmptyTrash,
+  type Acknowledgement,
+} from '../core/consent'
 import { createChromeBaton, runtimeSendMessage, storageGet, storageRemove, storageSet } from './api'
 
 const LOG = '[gpdt:content]'
@@ -33,15 +43,19 @@ const LOG = '[gpdt:content]'
 const STORAGE_KEYS = {
   /** Set by the popup; observed once when the engine finishes. */
   emptyTrashAfter: 'gpdt_emptyAfter',
-  /** Consent acknowledgment for destructive runs (v3). */
-  consent: 'gpdt_consent_v3',
-  /**
-   * Permanent empty-trash acknowledgement (v3). Required — in addition
-   * to the general consent — before a real run that selects the
-   * permanent "Empty trash afterwards" option is admitted.
-   */
-  emptyTrashAck: 'gpdt_emptyTrashAck_v3',
+  consent: CONSENT_KEY,
+  emptyTrashAck: EMPTY_TRASH_ACK_KEY,
 } as const
+
+async function readChromeAcknowledgement(key: string): Promise<Acknowledgement> {
+  try {
+    const data = await storageGet([key])
+    return { readable: true, acknowledged: Boolean(data[key]) }
+  } catch (err) {
+    console.warn(`${LOG} acknowledgement read failed (${key}):`, err)
+    return { readable: false, acknowledged: false }
+  }
+}
 
 // ─── Engine lifecycle ───────────────────────────────────────────
 
@@ -60,8 +74,8 @@ const start = async (opts: StartOptions): Promise<{ ok: boolean; error?: string 
   if (!isSupportedPhotosUrl(window.location.href)) {
     return { ok: false, error: 'Not on photos.google.com.' }
   }
-  if (engine || runPromise || starting) {
-    return { ok: false, error: 'A run is already in progress — stop it first.' }
+  if (!admitConcurrentStart(engine !== null || runPromise !== null || starting).ok) {
+    return { ok: false, error: RUN_IN_PROGRESS_ERROR }
   }
   starting = true
   try {
@@ -70,31 +84,17 @@ const start = async (opts: StartOptions): Promise<{ ok: boolean; error?: string 
     const emptyTrashAfter = opts.emptyTrashAfter ?? false
     const filter = opts.filter ?? { kind: 'all' as const }
 
+    let consent: Acknowledgement = { readable: true, acknowledged: false }
+    let emptyTrashAck: Acknowledgement = { readable: true, acknowledged: false }
     if (!dryRun) {
-      try {
-        const data = await storageGet([STORAGE_KEYS.consent])
-        if (!data[STORAGE_KEYS.consent]) {
-          return { ok: false, error: 'Consent required — confirm the safety notice in the popup first.' }
-        }
-      } catch (err) {
-        console.warn(`${LOG} consent read failed:`, err)
-        return { ok: false, error: 'Could not read consent state.' }
-      }
-
+      consent = await readChromeAcknowledgement(STORAGE_KEYS.consent)
       if (emptyTrashAfter) {
-        try {
-          const data = await storageGet([STORAGE_KEYS.emptyTrashAck])
-          if (!data[STORAGE_KEYS.emptyTrashAck]) {
-            return {
-              ok: false,
-              error: 'Permanent empty-trash consent required — confirm the permanent-action warning in the popup first.',
-            }
-          }
-        } catch (err) {
-          console.warn(`${LOG} empty-trash consent read failed:`, err)
-          return { ok: false, error: 'Could not read permanent empty-trash consent state.' }
-        }
+        emptyTrashAck = await readChromeAcknowledgement(STORAGE_KEYS.emptyTrashAck)
       }
+    }
+    const admission = admitDestructiveRun({ dryRun, emptyTrashAfter, consent, emptyTrashAck })
+    if (!admission.ok) {
+      return { ok: false, error: EXTENSION_ADMISSION_ERROR[admission.reason] }
     }
 
     try {
@@ -159,13 +159,6 @@ async function maybeChainEmptyTrash(
   dryRun: boolean,
   result: Progress,
 ): Promise<void> {
-  if (local.isStopped || dryRun) return
-  if (result.status !== 'done' || result.deleted <= 0) {
-    console.warn(`${LOG} skipping empty-trash navigation — status=${result.status}, deleted=${result.deleted}`)
-    await clearEmptyAfter()
-    return
-  }
-
   let wantEmpty = false
   try {
     const data = await storageGet([STORAGE_KEYS.emptyTrashAfter])
@@ -174,7 +167,18 @@ async function maybeChainEmptyTrash(
     console.warn(`${LOG} storage read failed; skipping empty-trash navigation:`, err)
   }
   await clearEmptyAfter()
-  if (!wantEmpty) return
+  if (!shouldNavigateToEmptyTrash({
+    dryRun,
+    emptyTrashAfter: wantEmpty,
+    stopped: local.isStopped,
+    status: result.status,
+    deleted: result.deleted,
+  })) {
+    if (wantEmpty) {
+      console.warn(`${LOG} skipping empty-trash navigation — status=${result.status}, deleted=${result.deleted}`)
+    }
+    return
+  }
 
   console.log(`${LOG} engine done — emptyTrashAfter set, navigating to /trash`)
   const ok = await baton.writePending()

--- a/src/extension/popup/popup.ts
+++ b/src/extension/popup/popup.ts
@@ -8,6 +8,12 @@ import {
   isSupportedPhotosUrl,
   type PhotosView,
 } from '../../core/surface'
+import {
+  CONSENT_KEY,
+  EMPTY_TRASH_ACK_KEY,
+  admitDestructiveRun,
+  type Acknowledgement,
+} from '../../core/consent'
 import { storageGet, storageSet, tabsCreate, tabsQuery, tabsSendMessage } from '../api'
 import type { PhotoFilter, PhotoType } from '../../core/photo-filter'
 import { ACTIVE_STATUSES, TERMINAL_STATUSES, type RunStatus } from '../../core/status'
@@ -96,8 +102,6 @@ let lastReport: { total: number; labels: string[] } | null = null
 let currentView: PhotosView | null = null
 let surfaceReady = false
 
-const CONSENT_KEY = 'gpdt_consent_v3'
-const EMPTY_TRASH_ACK_KEY = 'gpdt_emptyTrashAck_v3'
 const PRO_TOKEN_KEY = 'proToken'
 
 // ─── Locale init ────────────────────────────────────────────────
@@ -459,12 +463,12 @@ const refreshEmptyTrashWarning = (): void => {
   emptyTrashWarning.classList.toggle('hidden', !emptyTrashInput.checked)
 }
 
-async function consentAcknowledged(): Promise<boolean> {
+async function readPopupAcknowledgement(key: string): Promise<Acknowledgement> {
   try {
-    const data = await storageGet([CONSENT_KEY])
-    return data[CONSENT_KEY] === true
+    const data = await storageGet([key])
+    return { readable: true, acknowledged: data[key] === true }
   } catch {
-    return false
+    return { readable: false, acknowledged: false }
   }
 }
 
@@ -473,16 +477,6 @@ async function acknowledgeConsent(): Promise<void> {
     await storageSet({ [CONSENT_KEY]: true })
   } catch (err) {
     console.warn(`${LOG} consent persist failed:`, err)
-  }
-}
-
-/** Permanent empty-trash acknowledgement (parallel to the general consent). */
-async function emptyTrashAcknowledged(): Promise<boolean> {
-  try {
-    const data = await storageGet([EMPTY_TRASH_ACK_KEY])
-    return data[EMPTY_TRASH_ACK_KEY] === true
-  } catch {
-    return false
   }
 }
 
@@ -536,7 +530,13 @@ startBtn.addEventListener('click', async () => {
     saveSettings()
     hideError()
 
-    if (!opts.dryRun && (!(await consentAcknowledged()) || (opts.emptyTrashAfter && !(await emptyTrashAcknowledged())))) {
+    const admission = admitDestructiveRun({
+      dryRun: opts.dryRun,
+      emptyTrashAfter: opts.emptyTrashAfter,
+      consent: await readPopupAcknowledgement(CONSENT_KEY),
+      emptyTrashAck: await readPopupAcknowledgement(EMPTY_TRASH_ACK_KEY),
+    })
+    if (!admission.ok) {
       pendingStart = opts
       consentPermanent.classList.toggle('hidden', !opts.emptyTrashAfter)
       consentCheck.checked = false

--- a/src/ui/panel/panel.ts
+++ b/src/ui/panel/panel.ts
@@ -5,6 +5,7 @@
  * i18n'd surface with the same controls (parity by contract, not code).
  */
 import type { PageRunner, PanelRunOptions } from '../../core/page-runner'
+import { admitDestructiveRun } from '../../core/consent'
 import { admitSurface, describePhotosView } from '../../core/surface'
 import { formatElapsed, formatEta } from '../../core/utils'
 import { ACTIVE_STATUSES } from '../../core/status'
@@ -245,7 +246,13 @@ export function mountPanel(container: HTMLElement, runner: PageRunner): void {
 
   startBtn.addEventListener('click', () => {
     const opts = readOptions()
-    if (!opts.dryRun && (!runner.consentAcknowledged() || (opts.emptyTrashAfter && !runner.emptyTrashAcknowledged()))) {
+    const admission = admitDestructiveRun({
+      dryRun: opts.dryRun,
+      emptyTrashAfter: opts.emptyTrashAfter,
+      consent: { readable: true, acknowledged: runner.consentAcknowledged() },
+      emptyTrashAck: { readable: true, acknowledged: runner.emptyTrashAcknowledged() },
+    })
+    if (!admission.ok) {
       pendingStart = opts
       consentPermanent.style.display = opts.emptyTrashAfter ? 'block' : 'none'
       consentCheck.checked = false

--- a/tests/consent.test.ts
+++ b/tests/consent.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  CONSENT_KEY,
+  EMPTY_TRASH_ACK_KEY,
+  EXTENSION_ADMISSION_ERROR,
+  LOCAL_ACK_VALUE,
+  RUN_IN_PROGRESS_ERROR,
+  admitConcurrentStart,
+  admitDestructiveRun,
+  readLocalAcknowledgement,
+  shouldNavigateToEmptyTrash,
+  throwForDestructiveRefusal,
+  writeLocalAcknowledgement,
+  ConsentRequiredError,
+  PermanentActionRequiredError,
+} from '../src/core/consent'
+import type { RunStatus } from '../src/core/status'
+
+const ack = (acknowledged: boolean, readable = true) => ({ readable, acknowledged })
+
+describe('storage key contract', () => {
+  it('publishes the v3 acknowledgement key names', () => {
+    expect(CONSENT_KEY).toBe('gpdt_consent_v3')
+    expect(EMPTY_TRASH_ACK_KEY).toBe('gpdt_emptyTrashAck_v3')
+    expect(LOCAL_ACK_VALUE).toBe('1')
+  })
+})
+
+describe('admitDestructiveRun', () => {
+  it('admits a dry-run with no consent and no empty-trash acknowledgement', () => {
+    expect(admitDestructiveRun({
+      dryRun: true,
+      emptyTrashAfter: false,
+      consent: ack(false),
+      emptyTrashAck: ack(false),
+    })).toEqual({ ok: true })
+  })
+
+  it('admits a dry-run even when empty-trash is selected and storage is unreadable', () => {
+    expect(admitDestructiveRun({
+      dryRun: true,
+      emptyTrashAfter: true,
+      consent: ack(false, false),
+      emptyTrashAck: ack(false, false),
+    })).toEqual({ ok: true })
+  })
+
+  it('refuses a real run when consent is missing', () => {
+    expect(admitDestructiveRun({
+      dryRun: false,
+      emptyTrashAfter: false,
+      consent: ack(false),
+      emptyTrashAck: ack(false),
+    })).toEqual({ ok: false, reason: 'consent-missing' })
+  })
+
+  it('refuses a real run when consent is unreadable', () => {
+    expect(admitDestructiveRun({
+      dryRun: false,
+      emptyTrashAfter: false,
+      consent: ack(true, false),
+      emptyTrashAck: ack(true),
+    })).toEqual({ ok: false, reason: 'consent-unreadable' })
+  })
+
+  it('refuses a real empty-trash run when the permanent acknowledgement is missing', () => {
+    expect(admitDestructiveRun({
+      dryRun: false,
+      emptyTrashAfter: true,
+      consent: ack(true),
+      emptyTrashAck: ack(false),
+    })).toEqual({ ok: false, reason: 'empty-trash-ack-missing' })
+  })
+
+  it('refuses a real empty-trash run when the permanent acknowledgement is unreadable', () => {
+    expect(admitDestructiveRun({
+      dryRun: false,
+      emptyTrashAfter: true,
+      consent: ack(true),
+      emptyTrashAck: ack(true, false),
+    })).toEqual({ ok: false, reason: 'empty-trash-ack-unreadable' })
+  })
+
+  it('checks consent before the empty-trash acknowledgement', () => {
+    expect(admitDestructiveRun({
+      dryRun: false,
+      emptyTrashAfter: true,
+      consent: ack(false),
+      emptyTrashAck: ack(false),
+    })).toEqual({ ok: false, reason: 'consent-missing' })
+  })
+
+  it('admits a real run when consent is present and empty-trash is not selected', () => {
+    expect(admitDestructiveRun({
+      dryRun: false,
+      emptyTrashAfter: false,
+      consent: ack(true),
+      emptyTrashAck: ack(false),
+    })).toEqual({ ok: true })
+  })
+
+  it('admits a real empty-trash run when both acknowledgements are present', () => {
+    expect(admitDestructiveRun({
+      dryRun: false,
+      emptyTrashAfter: true,
+      consent: ack(true),
+      emptyTrashAck: ack(true),
+    })).toEqual({ ok: true })
+  })
+})
+
+describe('shouldNavigateToEmptyTrash', () => {
+  const clean = {
+    dryRun: false,
+    emptyTrashAfter: true,
+    stopped: false,
+    status: 'done' as RunStatus,
+    deleted: 1,
+  }
+
+  it('admits navigation only after a clean real run that deleted at least one item', () => {
+    expect(shouldNavigateToEmptyTrash(clean)).toBe(true)
+  })
+
+  it('refuses a dry-run', () => {
+    expect(shouldNavigateToEmptyTrash({ ...clean, dryRun: true })).toBe(false)
+  })
+
+  it('refuses when the empty-trash option was not selected', () => {
+    expect(shouldNavigateToEmptyTrash({ ...clean, emptyTrashAfter: false })).toBe(false)
+  })
+
+  it('refuses a stopped run even if items were deleted', () => {
+    expect(shouldNavigateToEmptyTrash({ ...clean, stopped: true, deleted: 4 })).toBe(false)
+  })
+
+  it('refuses non-done statuses', () => {
+    for (const status of ['idle', 'error', 'paused', 'navigatingTrash', 'emptyingTrash'] as RunStatus[]) {
+      expect(shouldNavigateToEmptyTrash({ ...clean, status })).toBe(false)
+    }
+  })
+
+  it('refuses a clean finish that deleted nothing', () => {
+    expect(shouldNavigateToEmptyTrash({ ...clean, deleted: 0 })).toBe(false)
+  })
+
+  it('refuses non-positive deleted counts, including NaN', () => {
+    expect(shouldNavigateToEmptyTrash({ ...clean, deleted: -1 })).toBe(false)
+    expect(shouldNavigateToEmptyTrash({ ...clean, deleted: Number.NaN })).toBe(false)
+  })
+})
+
+describe('admitConcurrentStart', () => {
+  it('admits the first start and refuses a second while occupied', () => {
+    expect(admitConcurrentStart(false)).toEqual({ ok: true })
+    expect(admitConcurrentStart(true)).toEqual({ ok: false, reason: 'run-in-progress' })
+  })
+})
+
+describe('public extension refusal tokens', () => {
+  it('keeps the IPC error strings stable', () => {
+    expect(EXTENSION_ADMISSION_ERROR['consent-missing']).toBe(
+      'Consent required — confirm the safety notice in the popup first.',
+    )
+    expect(EXTENSION_ADMISSION_ERROR['consent-unreadable']).toBe('Could not read consent state.')
+    expect(EXTENSION_ADMISSION_ERROR['empty-trash-ack-missing']).toBe(
+      'Permanent empty-trash consent required — confirm the permanent-action warning in the popup first.',
+    )
+    expect(EXTENSION_ADMISSION_ERROR['empty-trash-ack-unreadable']).toBe(
+      'Could not read permanent empty-trash consent state.',
+    )
+    expect(RUN_IN_PROGRESS_ERROR).toBe('A run is already in progress — stop it first.')
+  })
+})
+
+describe('throwForDestructiveRefusal', () => {
+  it('maps consent refusals to ConsentRequiredError', () => {
+    expect(() => throwForDestructiveRefusal('consent-missing')).toThrow(ConsentRequiredError)
+    expect(() => throwForDestructiveRefusal('consent-unreadable')).toThrow(ConsentRequiredError)
+  })
+
+  it('maps empty-trash refusals to PermanentActionRequiredError', () => {
+    expect(() => throwForDestructiveRefusal('empty-trash-ack-missing')).toThrow(PermanentActionRequiredError)
+    expect(() => throwForDestructiveRefusal('empty-trash-ack-unreadable')).toThrow(PermanentActionRequiredError)
+  })
+})
+
+describe('localStorage acknowledgement helpers', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals()
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('round-trips the local acknowledgement token', () => {
+    const store = new Map<string, string>()
+    vi.stubGlobal('window', {
+      localStorage: {
+        getItem: (k: string) => store.get(k) ?? null,
+        setItem: (k: string, v: string) => { store.set(k, v) },
+      },
+    } as unknown as Window & typeof globalThis)
+    expect(readLocalAcknowledgement(CONSENT_KEY)).toEqual({ readable: true, acknowledged: false })
+    writeLocalAcknowledgement(CONSENT_KEY)
+    expect(store.get(CONSENT_KEY)).toBe('1')
+    expect(readLocalAcknowledgement(CONSENT_KEY)).toEqual({ readable: true, acknowledged: true })
+  })
+
+  it('fail-closes when localStorage throws', () => {
+    vi.stubGlobal('window', {
+      localStorage: {
+        getItem: () => { throw new Error('denied') },
+        setItem: () => { throw new Error('denied') },
+      },
+    } as unknown as Window & typeof globalThis)
+    expect(readLocalAcknowledgement(CONSENT_KEY)).toEqual({ readable: false, acknowledged: false })
+    expect(() => writeLocalAcknowledgement(CONSENT_KEY)).not.toThrow()
+  })
+})

--- a/tests/delete-engine.test.ts
+++ b/tests/delete-engine.test.ts
@@ -101,11 +101,16 @@ class FakeDom implements EngineDom {
       this.clicks.push('delete')
     },
   }
+  /** When false, confirm is clicked but the selected-count never returns to 0. */
+  confirmClearsSelection = true
+
   private confirmBtn: ClickTarget = {
     click: () => {
       this.clicks.push('confirm')
-      // Deletion REMOVES the checked photos from the gallery DOM.
-      this.tiles = this.tiles.filter((t) => !t.checked)
+      if (this.confirmClearsSelection) {
+        // Deletion REMOVES the checked photos from the gallery DOM.
+        this.tiles = this.tiles.filter((t) => !t.checked)
+      }
       this.dialogOpen = false
     },
   }
@@ -492,6 +497,23 @@ describe('DeleteEngine — positive batch limit (fail closed)', () => {
     expect(result.error).toMatch(/maxCount must be a positive integer/)
     expect(result.total).toBeUndefined()
     expect(dom.clicks.some((c) => c.startsWith('tile:'))).toBe(false)
+  })
+})
+
+describe('DeleteEngine — batch verify (selected-count reset)', () => {
+  it('does not increment deleted when selected-count never returns to 0 after confirm', async () => {
+    const dom = new FakeDom()
+    dom.setTiles(['Photo - a'])
+    dom.confirmClearsSelection = false
+    const { engine } = makeEngine(dom, { maxCount: 1, actionTimeout: 30, pollDelay: 1 })
+
+    const result = await engine.run()
+
+    expect(result.status).toBe('error')
+    expect(result.deleted).toBe(0)
+    expect(result.error).toMatch(/never returned to 0/)
+    expect(dom.clicks).toContain('confirm')
+    expect(dom.tiles).toHaveLength(1)
   })
 })
 

--- a/tests/page-runner.test.ts
+++ b/tests/page-runner.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { PageRunner, ConsentRequiredError } from '../src/core/page-runner'
+import { PageRunner, ConsentRequiredError, PermanentActionRequiredError } from '../src/core/page-runner'
 import type { EngineDom, ClickTarget, PhotoTile, ScrollTarget } from '../src/core/dom-adapter'
-import type { EmptyTrashBaton } from '../src/core/empty-trash-baton'
+import { TRASH_URL, type EmptyTrashBaton } from '../src/core/empty-trash-baton'
+import { CONSENT_KEY, EMPTY_TRASH_ACK_KEY } from '../src/core/consent'
 import { diagnostics } from '../src/core/diagnostics'
 
 /**
@@ -15,9 +16,16 @@ class RunnerFakeDom implements EngineDom {
   tiles: { label: string; checked: boolean }[] = []
   cap = Number.MAX_SAFE_INTEGER
   clicks: string[] = []
+  holdSleep = false
+  private sleepResolvers: Array<() => void> = []
 
   setTiles(labels: string[]): void {
     this.tiles = labels.map((label) => ({ label, checked: false }))
+  }
+
+  releaseSleep(): void {
+    this.holdSleep = false
+    for (const resolve of this.sleepResolvers.splice(0)) resolve()
   }
 
   counterText(): string | null {
@@ -36,30 +44,53 @@ class RunnerFakeDom implements EngineDom {
   findConfirmButton(): ClickTarget | null { return this.confirmBtn }
   findScrollTarget(): ScrollTarget | null { return null }
   click(target: ClickTarget): void { target.click() }
-  async sleep(): Promise<void> { return undefined }
+  async sleep(): Promise<void> {
+    if (!this.holdSleep) return
+    await new Promise<void>((resolve) => { this.sleepResolvers.push(resolve) })
+  }
 }
 
-const fakeBaton = (): EmptyTrashBaton & { pending: { at: number } | null } => {
-  const state: { pending: { at: number } | null } = { pending: null }
+const fakeBaton = (): EmptyTrashBaton & {
+  pending: { at: number } | null
+  writes: number
+  writeOk: boolean
+} => {
+  const state: { pending: { at: number } | null; writes: number; writeOk: boolean } = {
+    pending: null,
+    writes: 0,
+    writeOk: true,
+  }
   return {
-    pending: state.pending,
+    get pending() { return state.pending },
+    get writes() { return state.writes },
+    get writeOk() { return state.writeOk },
+    set writeOk(v: boolean) { state.writeOk = v },
     async readPending() { return state.pending },
-    async writePending(at = Date.now()) { state.pending = { at }; return true },
+    async writePending(at = Date.now()) {
+      state.writes += 1
+      if (!state.writeOk) return false
+      state.pending = { at }
+      return true
+    },
     async clearPending() { state.pending = null },
   }
 }
 
-const stubWindow = () => {
+const stubWindow = (opts: { throwOnGet?: (key: string) => boolean } = {}) => {
   const store = new Map<string, string>()
+  const location = { href: 'https://photos.google.com/' }
   vi.stubGlobal('window', {
     localStorage: {
-      getItem: (k: string) => store.get(k) ?? null,
+      getItem: (k: string) => {
+        if (opts.throwOnGet?.(k)) throw new Error('storage unreadable')
+        return store.get(k) ?? null
+      },
       setItem: (k: string, v: string) => { store.set(k, v) },
       removeItem: (k: string) => { store.delete(k) },
     },
-    location: { href: 'https://photos.google.com/' },
+    location,
   } as unknown as Window & typeof globalThis)
-  return store
+  return { store, location }
 }
 
 const stubNavigator = () => {
@@ -84,6 +115,43 @@ describe('PageRunner — consent gate', () => {
     expect(runner.getStatus().running).toBe(false)
   })
 
+  it('refuses a destructive run when consent storage is unreadable', async () => {
+    stubWindow({ throwOnGet: (key) => key === CONSENT_KEY })
+    const runner = new PageRunner({ dom: new RunnerFakeDom() as unknown as EngineDom, baton: fakeBaton() })
+    await expect(runner.start({ maxCount: 500, dryRun: false, emptyTrashAfter: false, filter: { kind: 'all' } }))
+      .rejects.toBeInstanceOf(ConsentRequiredError)
+    expect(runner.getStatus().running).toBe(false)
+  })
+
+  it('refuses an empty-trash run without the permanent acknowledgement', async () => {
+    stubWindow()
+    const runner = new PageRunner({ dom: new RunnerFakeDom() as unknown as EngineDom, baton: fakeBaton() })
+    runner.acknowledgeConsent()
+    await expect(runner.start({ maxCount: 500, dryRun: false, emptyTrashAfter: true, filter: { kind: 'all' } }))
+      .rejects.toBeInstanceOf(PermanentActionRequiredError)
+    expect(runner.getStatus().running).toBe(false)
+  })
+
+  it('refuses an empty-trash run when the permanent acknowledgement is unreadable', async () => {
+    stubWindow({ throwOnGet: (key) => key === EMPTY_TRASH_ACK_KEY })
+    const runner = new PageRunner({ dom: new RunnerFakeDom() as unknown as EngineDom, baton: fakeBaton() })
+    runner.acknowledgeConsent()
+    await expect(runner.start({ maxCount: 500, dryRun: false, emptyTrashAfter: true, filter: { kind: 'all' } }))
+      .rejects.toBeInstanceOf(PermanentActionRequiredError)
+    expect(runner.getStatus().running).toBe(false)
+  })
+
+  it('admits a dry-run without consent and never clicks', async () => {
+    stubWindow()
+    const dom = new RunnerFakeDom()
+    dom.setTiles(['Photo - a'])
+    const runner = new PageRunner({ dom: dom as unknown as EngineDom, baton: fakeBaton() })
+    await runner.start({ maxCount: 500, dryRun: true, emptyTrashAfter: true, filter: { kind: 'all' } })
+    expect(runner.getStatus().running).toBe(false)
+    expect(dom.clicks).toHaveLength(0)
+    expect(runner.getSummary()?.total).toBe(1)
+  })
+
   it('runs after consent is acknowledged', async () => {
     stubWindow()
     const dom = new RunnerFakeDom()
@@ -95,6 +163,110 @@ describe('PageRunner — consent gate', () => {
     await runner.start({ maxCount: 500, dryRun: false, emptyTrashAfter: false, filter: { kind: 'all' } })
     expect(runner.getStatus().running).toBe(false)
     expect(dom.clicks).toContain('confirm')
+  })
+})
+
+describe('PageRunner — occupancy', () => {
+  it('does not start a second engine while the first run is settling', async () => {
+    stubWindow()
+    const dom = new RunnerFakeDom()
+    dom.holdSleep = true
+    dom.setTiles(['Photo - a', 'Photo - b'])
+    const runner = new PageRunner({ dom: dom as unknown as EngineDom, baton: fakeBaton() })
+    runner.acknowledgeConsent()
+
+    const first = runner.start({ maxCount: 500, dryRun: false, emptyTrashAfter: false, filter: { kind: 'all' } })
+    expect(runner.getStatus().running).toBe(true)
+    const second = runner.start({ maxCount: 500, dryRun: false, emptyTrashAfter: false, filter: { kind: 'all' } })
+    await expect(second).resolves.toBeUndefined()
+    expect(runner.getStatus().running).toBe(true)
+
+    dom.releaseSleep()
+    await first
+    expect(runner.getStatus().running).toBe(false)
+    expect(dom.clicks.filter((c) => c === 'confirm')).toHaveLength(1)
+  })
+})
+
+describe('PageRunner — empty-trash chain', () => {
+  it('navigates only after a clean real run that deleted at least one item', async () => {
+    const { location } = stubWindow()
+    const dom = new RunnerFakeDom()
+    dom.setTiles(['Photo - a'])
+    const baton = fakeBaton()
+    const runner = new PageRunner({ dom: dom as unknown as EngineDom, baton })
+    runner.acknowledgeConsent()
+    runner.acknowledgeEmptyTrash()
+
+    await runner.start({ maxCount: 500, dryRun: false, emptyTrashAfter: true, filter: { kind: 'all' } })
+
+    expect(baton.writes).toBe(1)
+    expect(baton.pending).not.toBeNull()
+    expect(location.href).toBe(TRASH_URL)
+  })
+
+  it('does not navigate after a dry-run', async () => {
+    const { location } = stubWindow()
+    const dom = new RunnerFakeDom()
+    dom.setTiles(['Photo - a'])
+    const baton = fakeBaton()
+    const runner = new PageRunner({ dom: dom as unknown as EngineDom, baton })
+
+    await runner.start({ maxCount: 500, dryRun: true, emptyTrashAfter: true, filter: { kind: 'all' } })
+
+    expect(baton.writes).toBe(0)
+    expect(location.href).toBe('https://photos.google.com/')
+  })
+
+  it('does not navigate when a real run deleted nothing', async () => {
+    const { location } = stubWindow()
+    const dom = new RunnerFakeDom()
+    const baton = fakeBaton()
+    const runner = new PageRunner({ dom: dom as unknown as EngineDom, baton })
+    runner.acknowledgeConsent()
+    runner.acknowledgeEmptyTrash()
+
+    await runner.start({ maxCount: 500, dryRun: false, emptyTrashAfter: true, filter: { kind: 'all' } })
+
+    expect(baton.writes).toBe(0)
+    expect(location.href).toBe('https://photos.google.com/')
+  })
+
+  it('does not navigate when the run is stopped', async () => {
+    const { location } = stubWindow()
+    const dom = new RunnerFakeDom()
+    dom.holdSleep = true
+    dom.setTiles(['Photo - a'])
+    const baton = fakeBaton()
+    const runner = new PageRunner({ dom: dom as unknown as EngineDom, baton })
+    runner.acknowledgeConsent()
+    runner.acknowledgeEmptyTrash()
+
+    const started = runner.start({ maxCount: 500, dryRun: false, emptyTrashAfter: true, filter: { kind: 'all' } })
+    expect(runner.getStatus().running).toBe(true)
+    runner.stop()
+    dom.releaseSleep()
+    await started
+
+    expect(baton.writes).toBe(0)
+    expect(location.href).toBe('https://photos.google.com/')
+  })
+
+  it('does not navigate when the baton cannot be persisted', async () => {
+    const { location } = stubWindow()
+    const dom = new RunnerFakeDom()
+    dom.setTiles(['Photo - a'])
+    const baton = fakeBaton()
+    baton.writeOk = false
+    const runner = new PageRunner({ dom: dom as unknown as EngineDom, baton })
+    runner.acknowledgeConsent()
+    runner.acknowledgeEmptyTrash()
+
+    await runner.start({ maxCount: 500, dryRun: false, emptyTrashAfter: true, filter: { kind: 'all' } })
+
+    expect(baton.writes).toBe(1)
+    expect(baton.pending).toBeNull()
+    expect(location.href).toBe('https://photos.google.com/')
   })
 })
 

--- a/tests/ui-wiring.test.ts
+++ b/tests/ui-wiring.test.ts
@@ -1,16 +1,7 @@
 /**
- * Cross-surface wiring contracts.
- *
- * TypeScript cannot see DOM ids or message-action strings — a renamed id
- * or a mistyped action compiles fine and breaks at runtime (a null
- * element crash, or a popup button that silently does nothing). These
- * tests parse the actual sources and assert the contracts hold:
- *   1. Every getElementById/$() target exists in the HTML/template.
- *   2. Every message action the popup sends is handled by the content
- *      script, and vice versa.
- *   3. The consent storage key is identical across popup, content, and
- *      the in-page runner (a mismatch would make the consent gate
- *      permanently refuse real runs).
+ * Cross-surface wiring contracts whose text *is* the postcondition:
+ * published popup/panel DOM ids, and the popup↔content message-action
+ * set. Implementation source greps are not oracles.
  */
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
@@ -61,110 +52,16 @@ describe('content <-> popup message contract', () => {
   })
 })
 
-describe('consent storage key contract', () => {
-  it('popup, content, and page-runner use the same consent key', () => {
-    const popupTs = read('src/extension/popup/popup.ts')
-    const contentTs = read('src/extension/content.ts')
-    const runnerTs = read('src/core/page-runner.ts')
-    const popupKey = popupTs.match(/CONSENT_KEY = '([^']+)'/)?.[1]
-    const contentKey = contentTs.match(/consent: '([^']+)'/)?.[1]
-    const runnerKey = runnerTs.match(/CONSENT_KEY = '([^']+)'/)?.[1]
-    expect(popupKey).toBeTruthy()
-    expect(contentKey).toBeTruthy()
-    expect(runnerKey).toBeTruthy()
-    expect(new Set([popupKey, contentKey, runnerKey]).size).toBe(1)
-  })
-})
-
-describe('GPDT-ENTER surface contract', () => {
-  it('popup admits tabs via isSupportedPhotosUrl, not a substring includes', () => {
-    const popupTs = read('src/extension/popup/popup.ts')
-    expect(popupTs).toContain('isSupportedPhotosUrl')
-    expect(popupTs).not.toMatch(/includes\(['"]photos\.google\.com['"]\)/)
-  })
-
-  it('userscript and standalone activate only through activateLocalSurface', () => {
-    const userscript = read('src/userscript/google-photos-delete.user.ts')
-    const standalone = read('src/standalone/inject.ts')
-    expect(userscript).toContain('activateLocalSurface')
-    expect(standalone).toContain('activateLocalSurface')
-  })
-
-  it('popup and panel offer a click-free dry-run control', () => {
+describe('published permanent empty-trash warning copy', () => {
+  it('popup HTML presents the permanent-action warning', () => {
     const popupHtml = read('src/extension/popup/popup.html')
+    expect(popupHtml).toContain('id="empty-trash-warning"')
+    expect(popupHtml).toContain('"Empty trash afterwards" is PERMANENT — no recovery.')
+  })
+
+  it('panel template presents the permanent-action warning', () => {
     const panelTs = read('src/ui/panel/panel.ts')
-    expect(popupHtml).toMatch(/id="dry-run"/)
-    expect(panelTs).toMatch(/id="gpdt-dryrun"/)
-  })
-
-  it('popup names the current view as the action scope', () => {
-    const popupHtml = read('src/extension/popup/popup.html')
-    const popupTs = read('src/extension/popup/popup.ts')
-    expect(popupHtml).toMatch(/id="scope"/)
-    expect(popupTs).toContain('admitSurface')
-    expect(popupTs).toContain('scope.actingOn')
-  })
-})
-
-describe('permanent empty-trash acknowledgement contract', () => {
-  it('popup, content, and page-runner use the same empty-trash acknowledgement key', () => {
-    const popupTs = read('src/extension/popup/popup.ts')
-    const contentTs = read('src/extension/content.ts')
-    const runnerTs = read('src/core/page-runner.ts')
-    const popupKey = popupTs.match(/EMPTY_TRASH_ACK_KEY = '([^']+)'/)?.[1]
-    const contentKey = contentTs.match(/emptyTrashAck: '([^']+)'/)?.[1]
-    const runnerKey = runnerTs.match(/EMPTY_TRASH_ACK_KEY = '([^']+)'/)?.[1]
-    expect(popupKey).toBeTruthy()
-    expect(contentKey).toBeTruthy()
-    expect(runnerKey).toBeTruthy()
-    expect(new Set([popupKey, contentKey, runnerKey]).size).toBe(1)
-  })
-
-  it('content refuses a permanent empty-trash run without the acknowledgement', () => {
-    const contentTs = read('src/extension/content.ts')
-    // The ack gate lives on the non-dry path and is read through the
-    // same storage wrapper as the general consent.
-    expect(contentTs).toContain('STORAGE_KEYS.emptyTrashAck')
-    expect(contentTs).toContain('if (emptyTrashAfter)')
-    expect(contentTs).toContain("error: 'Permanent empty-trash consent required")
-    expect(contentTs).toContain("error: 'Could not read permanent empty-trash consent state.'")
-  })
-
-  it('page-runner refuses a permanent empty-trash run without the acknowledgement', () => {
-    const runnerTs = read('src/core/page-runner.ts')
-    expect(runnerTs).toContain('opts.emptyTrashAfter && !this.emptyTrashAcknowledged()')
-    expect(runnerTs).toContain('export class PermanentActionRequiredError')
-    expect(runnerTs).toContain('acknowledgeEmptyTrash(): void')
-  })
-})
-
-describe('permanent empty-trash warning is visible on selection', () => {
-  it('popup shows the permanent-action warning the moment Empty trash is selected', () => {
-    const popupTs = read('src/extension/popup/popup.ts')
-    const popupHtml = read('src/extension/popup/popup.html')
-    expect(popupHtml).toMatch(/id="empty-trash-warning"/)
-    expect(popupHtml).toMatch(/data-i18n="consent\.permanentNote"/)
-    expect(popupTs).toContain("const emptyTrashWarning = document.getElementById('empty-trash-warning')")
-    expect(popupTs).toContain("emptyTrashInput.addEventListener('change'")
-    expect(popupTs).toContain("emptyTrashWarning.classList.toggle('hidden', !emptyTrashInput.checked)")
-  })
-
-  it('panel shows the permanent-action warning the moment Empty trash is selected', () => {
-    const panelTs = read('src/ui/panel/panel.ts')
-    expect(panelTs).toMatch(/id="gpdt-empty-warning"/)
-    expect(panelTs).toContain("const emptyWarning = $<HTMLElement>('gpdt-empty-warning')")
-    expect(panelTs).toContain("emptyInput.addEventListener('change'")
-    expect(panelTs).toContain("emptyWarning.style.display = emptyInput.checked ? 'block' : 'none'")
-  })
-
-  it('popup and panel gate a permanent empty-trash run on the acknowledgement, not only on consent', () => {
-    const popupTs = read('src/extension/popup/popup.ts')
-    const panelTs = read('src/ui/panel/panel.ts')
-    expect(popupTs).toContain('opts.emptyTrashAfter && !(await emptyTrashAcknowledged())')
-    expect(panelTs).toContain('opts.emptyTrashAfter && !runner.emptyTrashAcknowledged()')
-    // Both surfaces record the acknowledgement at the same confirm
-    // moment where the permanent warning is visible.
-    expect(popupTs).toContain("if (pendingStart?.emptyTrashAfter) await acknowledgeEmptyTrash()")
-    expect(panelTs).toContain("if (pendingStart?.emptyTrashAfter) runner.acknowledgeEmptyTrash()")
+    expect(panelTs).toContain('id="gpdt-empty-warning"')
+    expect(panelTs).toContain('"Empty trash afterwards" is PERMANENT with no recovery.')
   })
 })


### PR DESCRIPTION
## Identity

- **identity:** `GPDT-CONSENT` (admit explicit destructive intent), plus the empty-trash chain predicate of `GPDT-TRASH-HANDOFF` and the single-run occupancy of `GPDT-CONTROL`
- **fate:** `live`
- **destination revision:** `ca5c1dc669a93c31929b70b9716f8b8913519b41` (`docs/vision.md` + `docs/capabilities.md` — store locators dest-lock #16)
- **candidate_sha:** `f6e6ed14d14d4ede926eab1cfd69f8a1bc261955`

## Write/effect set (source only)

One fail-closed writer for destructive admission, empty-trash navigation, and concurrent-start occupancy. Surfaces read their own storage backends and pass interpreted acknowledgements; they do not keep a second if-ladder.

Files (this PR):

- `src/core/consent.ts` — **sole writer**: `admitDestructiveRun`, `shouldNavigateToEmptyTrash`, `admitConcurrentStart`, localStorage acknowledgement helpers, public extension IPC tokens, and the consent/permanent-action error classes.
- `src/core/page-runner.ts` — userscript/panel enforcement calls the writer; error classes re-exported for existing callers.
- `src/extension/content.ts` — extension enforcement calls the same writer; occupancy remains `engine || runPromise || starting` at the surface; empty-trash flag is always cleared before the chain predicate.
- `src/extension/popup/popup.ts` and `src/ui/panel/panel.ts` — UI gates call `admitDestructiveRun`. Popup chrome ack stays `=== true`; content stays `Boolean(value)`; panel/userscript stays localStorage `'1'`.
- `src/core/index.ts` — barrel exports.
- `tests/consent.test.ts` — writer postconditions (policy matrix, IPC tokens, localStorage fail-closed).
- `tests/page-runner.test.ts` — unreadable storage, permanent-action refusal, dry-run without consent, occupancy, empty-trash chain (clean navigate / dry-run / deleted=0 / stopped / writePending false).
- `tests/delete-engine.test.ts` — confirm click does not increment `deleted` when the selected-count never returns to 0.
- `tests/ui-wiring.test.ts` — hard-cut of consent/ENTER implementation-source greps. Kept legal goldens: published DOM ids vs `getElementById`/`$()`, popup↔content message-action parity, published PERMANENT warning copy.
- `docs/capabilities.md` — evidence-path locators only (identity / fate / depends / done-when unchanged).

Does not pin Bun. Does not bump version or CHANGELOG. Does not invent Firefox/AMO/Edge/Greasy Fork dest. Does not claim `GPDT-EVIDENCE` live. No store publish; no live deletions.

## Done-when (oracle, named at source)

1. Every non-dry run is refused when the shared local consent acknowledgement is absent or unreadable; unreadable is checked before missing; consent is checked before the empty-trash acknowledgement. Dry-run always admits.
2. Choosing the permanent empty-trash option makes that consequence visible before admission (published warning copy) and additionally refuses a real empty-trash run without the permanent acknowledgement (or when that acknowledgement is unreadable).
3. Empty-trash navigation occurs only after a clean real run that deleted at least one item (`!dryRun && emptyTrashAfter && !stopped && status === 'done' && deleted > 0`; NaN/≤0 fail-closed). A failed baton persist does not navigate.
4. A supported surface cannot start a second engine while the first run is settling.
5. A batch contributes to `deleted` only after the selected-count returns to 0; confirm-without-reset does not increment.

## Evidence layer

Source / local tests. Not CI, not landed, not live-browser, not store.

Run locally at `candidate_sha` (`f6e6ed14d14d4ede926eab1cfd69f8a1bc261955`, working tree clean):

- `bun run typecheck` — pass
- `bun run lint` — pass
- `bun run test` — 235 passed (18 files)
- `bun run build` — pass (Chrome + Firefox extension, standalone, userscript)
- `bun run verify` — pass (all artifacts consistent)

No live Google Photos session; no destructive action was performed.

## Recovery

Revert this PR / drop this branch. No data migration, no live writer, no store publish. Existing stored consents remain valid.

## Next action

High-harm (deletion + consent/identity). A different session reviews this exact SHA independently. Do not merge from the author session. A head move voids the review. The forge waits.

- base: `master@ca5c1dc669a93c31929b70b9716f8b8913519b41`